### PR TITLE
fix: runtime error

### DIFF
--- a/packages/apps/bridge.sh
+++ b/packages/apps/bridge.sh
@@ -245,6 +245,8 @@ function initUitls() {
             ChainConfig,
             ChainConfig
         > {
+            static readonly alias: string = '${name}Bridge';
+
             back(payload: IssuingPayload, fee: BN): Observable<Tx> {
                 console.log(payload, fee);
                 return EMPTY;
@@ -290,7 +292,7 @@ function updatePredicateFns() {
 
 function updateBridgesIndexer() {
     echo "
-        export { $1, $2 } from './'$3;
+        export { $1, $2 } from './$3';
     " >>'./bridges/index.ts'
 }
 

--- a/packages/apps/bridges/bridges.ts
+++ b/packages/apps/bridges/bridges.ts
@@ -25,7 +25,7 @@ export const bridgeConstructors = [
 export function bridgeFactory<C extends BridgeConfig, O extends ChainConfig, T extends ChainConfig>(
   config: BridgeBase
 ): Bridge<C, O, T> {
-  const Constructor = bridgeConstructors.find((item) => item.name === config.subClsName)!;
+  const Constructor = bridgeConstructors.find((item) => item.alias === config.subClsName)!;
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/packages/apps/bridges/celer/cBridge/utils/bridge.ts
+++ b/packages/apps/bridges/celer/cBridge/utils/bridge.ts
@@ -22,6 +22,8 @@ import { GetTransferStatusRequest, WithdrawLiquidityRequest, WithdrawMethodType 
 import { WithdrawReq, WithdrawType } from '../ts-proto/sgn/cbridge/v1/tx_pb';
 
 export class CBridgeBridge extends Bridge<CBridgeBridgeConfig, EthereumChainConfig, EthereumChainConfig> {
+  static readonly alias = 'CBridgeBridge';
+
   private prefix = hexToBn('0x6878000000000000');
   public client = new WebClient(`https://cbridge-prod2.celer.network`, null, null);
 

--- a/packages/apps/bridges/helix/substrate-dvm/utils/bridge.ts
+++ b/packages/apps/bridges/helix/substrate-dvm/utils/bridge.ts
@@ -18,6 +18,8 @@ import { TxValidation } from '../../../../model';
 import { IssuingPayload, RedeemPayload, SubstrateDVMBridgeConfig } from '../model';
 
 export class SubstrateDVMBridge extends Bridge<SubstrateDVMBridgeConfig, PolkadotChainConfig, DVMChainConfig> {
+  static readonly alias: string = 'SubstrateDVMBridge';
+
   back(payload: IssuingPayload): Observable<Tx> {
     const {
       sender,

--- a/packages/apps/bridges/helix/substrate-substrateDVM/utils/bridge.ts
+++ b/packages/apps/bridges/helix/substrate-substrateDVM/utils/bridge.ts
@@ -33,6 +33,8 @@ export class SubstrateSubstrateDVMBridge extends Bridge<
   PolkadotChainConfig,
   DVMChainConfig
 > {
+  static readonly alias: string = 'SubstrateSubstrateDVMBridge';
+
   back(payload: IssuingPayload, fee: BN): Observable<Tx> {
     const { sender, recipient, direction } = payload;
     const { from: departure, to } = direction;

--- a/packages/apps/bridges/helix/substrate-substrateParachain/utils/bridge.ts
+++ b/packages/apps/bridges/helix/substrate-substrateParachain/utils/bridge.ts
@@ -17,6 +17,8 @@ export class SubstrateSubstrateParachainBridge extends Bridge<
   PolkadotChainConfig,
   PolkadotChainConfig
 > {
+  static readonly alias: string = 'SubstrateSubstrateParachainBridge';
+
   back(payload: IssuingPayload, fee: BN): Observable<Tx> {
     const { sender, recipient, direction } = payload;
     const { from: departure, to } = direction;

--- a/packages/apps/bridges/helix/substrateDVM-ethereum/utils/bridge.ts
+++ b/packages/apps/bridges/helix/substrateDVM-ethereum/utils/bridge.ts
@@ -28,6 +28,8 @@ export class SubstrateDVMEthereumBridge extends Bridge<
   DVMChainConfig,
   EthereumChainConfig
 > {
+  static readonly alias: string = 'SubstrateDVMEthereumBridge';
+
   back(payload: IssuingPayload, fee: BN): Observable<Tx> {
     const { sender, recipient, direction } = payload;
     const { from: departure, to } = direction;

--- a/packages/apps/bridges/helix/substrateDVM-substrateDVM/utils/bridge-inner.ts
+++ b/packages/apps/bridges/helix/substrateDVM-substrateDVM/utils/bridge-inner.ts
@@ -13,6 +13,8 @@ export class SubstrateDVMInnerBridge extends Bridge<
   DVMChainConfig,
   DVMChainConfig
 > {
+  static readonly alias: string = 'SubstrateDVMInnerBridge';
+
   back(payload: IssuingPayload): Observable<Tx> {
     const {
       sender,

--- a/packages/apps/bridges/helix/substrateDVM-substrateDVM/utils/bridge.ts
+++ b/packages/apps/bridges/helix/substrateDVM-substrateDVM/utils/bridge.ts
@@ -18,6 +18,8 @@ export class SubstrateDVMSubstrateDVMBridge extends Bridge<
   DVMChainConfig,
   DVMChainConfig
 > {
+  static readonly alias: string = 'SubstrateDVMSubstrateDVMBridge';
+
   back(payload: IssuingPayload, fee: BN): Observable<Tx> {
     const { sender, recipient, direction, bridge } = payload;
     const { from: departure, to } = direction;

--- a/packages/apps/bridges/index.ts
+++ b/packages/apps/bridges/index.ts
@@ -33,3 +33,5 @@ export { SubstrateDVM2SubstrateDVM, SubstrateDVMInner } from './helix/substrateD
 export { Unavailable2Unknown, Unknown2Unavailable } from './unknown-unavailable';
 export { CrabParachain2Karura, Karura2CrabParachain } from './xcm/crabParachain-karura';
 export { CrabParachain2Moonriver, Moonriver2CrabParachain } from './xcm/crabParachain-moonriver';
+
+export { Pangolin2Pangoro, Pangoro2Pangolin } from './helix/pangolin-pangoro';

--- a/packages/apps/bridges/index.ts
+++ b/packages/apps/bridges/index.ts
@@ -33,5 +33,3 @@ export { SubstrateDVM2SubstrateDVM, SubstrateDVMInner } from './helix/substrateD
 export { Unavailable2Unknown, Unknown2Unavailable } from './unknown-unavailable';
 export { CrabParachain2Karura, Karura2CrabParachain } from './xcm/crabParachain-karura';
 export { CrabParachain2Moonriver, Moonriver2CrabParachain } from './xcm/crabParachain-moonriver';
-
-export { Pangolin2Pangoro, Pangoro2Pangolin } from './helix/pangolin-pangoro';

--- a/packages/apps/bridges/xcm/crabParachain-karura/utils/bridge.ts
+++ b/packages/apps/bridges/xcm/crabParachain-karura/utils/bridge.ts
@@ -15,6 +15,8 @@ export class CrabParachainKaruraBridge extends Bridge<
   ParachainChainConfig,
   ParachainChainConfig
 > {
+  static readonly alias = 'CrabParachainKaruraBridge';
+
   private patchAmount(departure: CrossToken<ParachainChainConfig>) {
     const pos = -3;
     const timestamp = Date.now().toString().slice(0, pos);

--- a/packages/apps/bridges/xcm/crabParachain-moonriver/utils/bridge.ts
+++ b/packages/apps/bridges/xcm/crabParachain-moonriver/utils/bridge.ts
@@ -22,6 +22,8 @@ export class CrabParachainMoonriverBridge extends Bridge<
   ParachainChainConfig,
   ParachainEthereumCompatibleChainConfig
 > {
+  static readonly alias = 'CrabParachainMoonriverBridge';
+
   private patchAmount(departure: CrossToken) {
     const pos = -3;
     const timestamp = Date.now().toString().slice(0, pos);

--- a/packages/apps/core/bridge.ts
+++ b/packages/apps/core/bridge.ts
@@ -42,6 +42,13 @@ export abstract class Bridge<
   Origin extends ChainConfig,
   Target extends ChainConfig
 > extends BridgeBase<B, Origin, Target> {
+  /**
+   * Will be generated automatically through `yarn init:bridge` command. alias === Constructor.name
+   *
+   * @see https://github.com/helix-bridge/helix-ui/issues/334
+   */
+  static readonly alias: string;
+
   protected readonly txValidationMessages = TxValidationMessages;
 
   abstract back(

--- a/packages/apps/utils/bridge/predicates.ts
+++ b/packages/apps/utils/bridge/predicates.ts
@@ -177,3 +177,7 @@ export const isCrabParachainMoonriver = or(isCrabParachain2Moonriver, isMoonrive
 export const isSubstrateDVM2Ethereum = or(predicate('darwinia-dvm', 'ethereum'), predicate('pangoro-dvm', 'goerli'));
 export const isEthereum2SubstrateDVM = or(predicate('ethereum', 'darwinia-dvm'), predicate('goerli', 'pangoro-dvm'));
 export const isSubstrateDVMEthereum = or(isSubstrateDVM2Ethereum, isEthereum2SubstrateDVM);
+
+export const isPangolin2Pangoro = predicate('pangolin', 'pangoro');
+export const isPangoro2Pangolin = predicate('pangoro', 'pangolin');
+export const isPangolinPangoro = or(isPangolin2Pangoro, isPangoro2Pangolin);

--- a/packages/shared/model/bridge/supports.ts
+++ b/packages/shared/model/bridge/supports.ts
@@ -33,4 +33,5 @@ export type BridgeName =
   | 'crabDVM-astar'
   | 'crabParachain-karura'
   | 'crabParachain-moonriver'
-  | 'substrateDVM-ethereum';
+  | 'substrateDVM-ethereum'
+  | 'pangolin-pangoro';


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Why do we need this pr?

#334 Actually it's a runtime error, because of the webpack plugin minify the Constructor name

Add an alias field to hold the origin constructor name, but it's better to modify the ```next.config.js``` configuration to prevent modifying

<!-- The number of related issues or features -->
