### PR TITLE
Verify chains configurations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,6 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_ICON: https://avatars.githubusercontent.com/u/51163350?s=48&v=4
           SLACK_MESSAGE: ${{ steps.changesets.outputs.publishedPackages }}
-          SLACK_TITLE: Publish
+          SLACK_TITLE: Published
           SLACK_USERNAME: Changesets
           SLACK_WEBHOOK: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/packages/chains/.eslintrc.cjs
+++ b/packages/chains/.eslintrc.cjs
@@ -6,4 +6,7 @@ module.exports = {
   parserOptions: {
     project: true,
   },
+  env: {
+    jest: true,
+  },
 };

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -12,22 +12,30 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
   },
   "license": "MIT",
   "devDependencies": {
     "@helixbridge/eslint-config": "workspace:*",
+    "@helixbridge/jest-presets": "workspace:*",
     "@helixbridge/tsconfig": "workspace:*",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20",
     "@typescript-eslint/parser": "^7.2.0",
     "eslint": "^8.57.0",
+    "jest": "^29.7.0",
     "tsup": "^8.2.3",
     "typescript": "^5.2.2"
   },
   "publishConfig": {
     "access": "public"
   },
+  "jest": {
+    "preset": "@helixbridge/jest-presets/node"
+  },
   "dependencies": {
+    "@helixbridge/helixconf": "^1.1.0",
     "viem": "2.18.0"
   }
 }

--- a/packages/chains/src/utils/index.test.ts
+++ b/packages/chains/src/utils/index.test.ts
@@ -1,0 +1,30 @@
+import { HelixChain } from "@helixbridge/helixconf";
+import { getChainByIdOrNetwork, getChains } from ".";
+import { ChainID } from "../types";
+
+const numberOfChains = Object.keys(ChainID).length / 2;
+const chains = getChains();
+
+test(`The number of chains should be equal to ${numberOfChains}`, () => {
+  expect(chains.length).toBe(numberOfChains);
+});
+
+describe.each(getChains())("$name", ({ id, network }) => {
+  if (network === "taiko" || network === "pangolin-dvm") {
+    /**
+     * @helixbridge/helixconf does not support these chains.
+     * Maybe we should remove these chains from @helixbridge/chains too.
+     */
+  } else {
+    test(`The 'network' should be configured correctly`, () => {
+      expect(network).toBe(HelixChain.get(id)?.code);
+    });
+  }
+
+  test(`getChainByIdOrNetwork(${id}) should return the correct chain`, () => {
+    expect(getChainByIdOrNetwork(id)?.network).toBe(network);
+  });
+  test(`getChainByIdOrNetwork('${network}') should return the correct chain`, () => {
+    expect(getChainByIdOrNetwork(network)?.id).toBe(id);
+  });
+});

--- a/packages/chains/tsconfig.json
+++ b/packages/chains/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["ES2020"],
     "outDir": "./dist",
-    "types": ["node"]
+    "types": ["jest", "node"]
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/jest-presets/node/jest-preset.js
+++ b/packages/jest-presets/node/jest-preset.js
@@ -1,0 +1,9 @@
+module.exports = {
+  roots: ["<rootDir>"],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest",
+  },
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  modulePathIgnorePatterns: ["<rootDir>/test/__fixtures__", "<rootDir>/node_modules", "<rootDir>/dist"],
+  preset: "ts-jest",
+};

--- a/packages/jest-presets/package.json
+++ b/packages/jest-presets/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@helixbridge/jest-presets",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "dependencies": {
+    "ts-jest": "^29.2.3"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
 
   packages/chains:
     dependencies:
+      "@helixbridge/helixconf":
+        specifier: ^1.1.0
+        version: 1.1.0
       viem:
         specifier: 2.18.0
         version: 2.18.0(typescript@5.5.4)
@@ -149,9 +152,15 @@ importers:
       "@helixbridge/eslint-config":
         specifier: workspace:*
         version: link:../config-eslint
+      "@helixbridge/jest-presets":
+        specifier: workspace:*
+        version: link:../jest-presets
       "@helixbridge/tsconfig":
         specifier: workspace:*
         version: link:../config-typescript
+      "@types/jest":
+        specifier: ^29.5.12
+        version: 29.5.12
       "@types/node":
         specifier: ^20
         version: 20.14.12
@@ -161,6 +170,9 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.14.12)
       tsup:
         specifier: ^8.2.3
         version: 8.2.3(@swc/core@1.7.1)(jiti@1.21.6)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5)
@@ -182,6 +194,12 @@ importers:
 
   packages/config-typescript: {}
 
+  packages/jest-presets:
+    dependencies:
+      ts-jest:
+        specifier: ^29.2.3
+        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0)(typescript@5.5.4)
+
 packages:
   "@adraffy/ens-normalize@1.10.0":
     resolution:
@@ -191,6 +209,11 @@ packages:
     resolution:
       { integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw== }
     engines: { node: ">=10" }
+
+  "@ampproject/remapping@2.3.0":
+    resolution:
+      { integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw== }
+    engines: { node: ">=6.0.0" }
 
   "@apollo/client@3.11.1":
     resolution:
@@ -211,10 +234,214 @@ packages:
       subscriptions-transport-ws:
         optional: true
 
+  "@babel/code-frame@7.24.7":
+    resolution:
+      { integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/compat-data@7.24.9":
+    resolution:
+      { integrity: sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/core@7.24.9":
+    resolution:
+      { integrity: sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/generator@7.24.10":
+    resolution:
+      { integrity: sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-compilation-targets@7.24.8":
+    resolution:
+      { integrity: sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-environment-visitor@7.24.7":
+    resolution:
+      { integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-function-name@7.24.7":
+    resolution:
+      { integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-hoist-variables@7.24.7":
+    resolution:
+      { integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-module-imports@7.24.7":
+    resolution:
+      { integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-module-transforms@7.24.9":
+    resolution:
+      { integrity: sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw== }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-plugin-utils@7.24.8":
+    resolution:
+      { integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-simple-access@7.24.7":
+    resolution:
+      { integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-split-export-declaration@7.24.7":
+    resolution:
+      { integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-string-parser@7.24.8":
+    resolution:
+      { integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-validator-identifier@7.24.7":
+    resolution:
+      { integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-validator-option@7.24.8":
+    resolution:
+      { integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helpers@7.24.8":
+    resolution:
+      { integrity: sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/highlight@7.24.7":
+    resolution:
+      { integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/parser@7.24.8":
+    resolution:
+      { integrity: sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w== }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
+
+  "@babel/plugin-syntax-async-generators@7.8.4":
+    resolution:
+      { integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-bigint@7.8.3":
+    resolution:
+      { integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-class-properties@7.12.13":
+    resolution:
+      { integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-import-meta@7.10.4":
+    resolution:
+      { integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-json-strings@7.8.3":
+    resolution:
+      { integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-jsx@7.24.7":
+    resolution:
+      { integrity: sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ== }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-logical-assignment-operators@7.10.4":
+    resolution:
+      { integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3":
+    resolution:
+      { integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-numeric-separator@7.10.4":
+    resolution:
+      { integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-object-rest-spread@7.8.3":
+    resolution:
+      { integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-optional-catch-binding@7.8.3":
+    resolution:
+      { integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-optional-chaining@7.8.3":
+    resolution:
+      { integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg== }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-top-level-await@7.14.5":
+    resolution:
+      { integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw== }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-typescript@7.24.7":
+    resolution:
+      { integrity: sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA== }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
   "@babel/runtime@7.24.8":
     resolution:
       { integrity: sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA== }
     engines: { node: ">=6.9.0" }
+
+  "@babel/template@7.24.7":
+    resolution:
+      { integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/traverse@7.24.8":
+    resolution:
+      { integrity: sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ== }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/types@7.24.9":
+    resolution:
+      { integrity: sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ== }
+    engines: { node: ">=6.9.0" }
+
+  "@bcoe/v8-coverage@0.2.3":
+    resolution:
+      { integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw== }
 
   "@changesets/apply-release-plan@7.0.4":
     resolution:
@@ -700,6 +927,10 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  "@helixbridge/helixconf@1.1.0":
+    resolution:
+      { integrity: sha512-sYa9X92MmRkMFnyhYLOehfEwgwmqnJQURLrMZ8mOHjjZbxF1xyENYB9UkiiK7abeYLXW/HVVRb6g1KeQUE+76w== }
+
   "@humanwhocodes/config-array@0.11.14":
     resolution:
       { integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg== }
@@ -721,9 +952,94 @@ packages:
       { integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA== }
     engines: { node: ">=12" }
 
+  "@istanbuljs/load-nyc-config@1.1.0":
+    resolution:
+      { integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ== }
+    engines: { node: ">=8" }
+
+  "@istanbuljs/schema@0.1.3":
+    resolution:
+      { integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA== }
+    engines: { node: ">=8" }
+
+  "@jest/console@29.7.0":
+    resolution:
+      { integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/core@29.7.0":
+    resolution:
+      { integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  "@jest/environment@29.7.0":
+    resolution:
+      { integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/expect-utils@29.7.0":
+    resolution:
+      { integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/expect@29.7.0":
+    resolution:
+      { integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/fake-timers@29.7.0":
+    resolution:
+      { integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/globals@29.7.0":
+    resolution:
+      { integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/reporters@29.7.0":
+    resolution:
+      { integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   "@jest/schemas@29.6.3":
     resolution:
       { integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/source-map@29.6.3":
+    resolution:
+      { integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/test-result@29.7.0":
+    resolution:
+      { integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/test-sequencer@29.7.0":
+    resolution:
+      { integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/transform@29.7.0":
+    resolution:
+      { integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/types@29.6.3":
+    resolution:
+      { integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw== }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
 
   "@jridgewell/gen-mapping@0.3.5":
@@ -1132,6 +1448,14 @@ packages:
     resolution:
       { integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA== }
 
+  "@sinonjs/commons@3.0.1":
+    resolution:
+      { integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ== }
+
+  "@sinonjs/fake-timers@10.3.0":
+    resolution:
+      { integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA== }
+
   "@stablelib/aead@1.0.1":
     resolution:
       { integrity: sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg== }
@@ -1323,6 +1647,22 @@ packages:
       react-native:
         optional: true
 
+  "@types/babel__core@7.20.5":
+    resolution:
+      { integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA== }
+
+  "@types/babel__generator@7.6.8":
+    resolution:
+      { integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw== }
+
+  "@types/babel__template@7.4.4":
+    resolution:
+      { integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A== }
+
+  "@types/babel__traverse@7.20.6":
+    resolution:
+      { integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg== }
+
   "@types/debug@4.1.12":
     resolution:
       { integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ== }
@@ -1330,6 +1670,26 @@ packages:
   "@types/estree@1.0.5":
     resolution:
       { integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw== }
+
+  "@types/graceful-fs@4.1.9":
+    resolution:
+      { integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ== }
+
+  "@types/istanbul-lib-coverage@2.0.6":
+    resolution:
+      { integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w== }
+
+  "@types/istanbul-lib-report@3.0.3":
+    resolution:
+      { integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA== }
+
+  "@types/istanbul-reports@3.0.4":
+    resolution:
+      { integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ== }
+
+  "@types/jest@29.5.12":
+    resolution:
+      { integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw== }
 
   "@types/ms@0.7.34":
     resolution:
@@ -1363,9 +1723,21 @@ packages:
     resolution:
       { integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ== }
 
+  "@types/stack-utils@2.0.3":
+    resolution:
+      { integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw== }
+
   "@types/trusted-types@2.0.7":
     resolution:
       { integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw== }
+
+  "@types/yargs-parser@21.0.3":
+    resolution:
+      { integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ== }
+
+  "@types/yargs@17.0.32":
+    resolution:
+      { integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog== }
 
   "@typescript-eslint/eslint-plugin@7.17.0":
     resolution:
@@ -1736,6 +2108,11 @@ packages:
       { integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw== }
     engines: { node: ">=6" }
 
+  ansi-escapes@4.3.2:
+    resolution:
+      { integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ== }
+    engines: { node: ">=8" }
+
   ansi-escapes@6.2.1:
     resolution:
       { integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig== }
@@ -1805,6 +2182,10 @@ packages:
     resolution:
       { integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw== }
 
+  async@3.2.5:
+    resolution:
+      { integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg== }
+
   atomic-sleep@1.0.0:
     resolution:
       { integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ== }
@@ -1817,6 +2198,36 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  babel-jest@29.7.0:
+    resolution:
+      { integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+    peerDependencies:
+      "@babel/core": ^7.8.0
+
+  babel-plugin-istanbul@6.1.1:
+    resolution:
+      { integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA== }
+    engines: { node: ">=8" }
+
+  babel-plugin-jest-hoist@29.6.3:
+    resolution:
+      { integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  babel-preset-current-node-syntax@1.0.1:
+    resolution:
+      { integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ== }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  babel-preset-jest@29.6.3:
+    resolution:
+      { integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+    peerDependencies:
+      "@babel/core": ^7.0.0
 
   balanced-match@1.0.2:
     resolution:
@@ -1859,6 +2270,19 @@ packages:
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
 
+  bs-logger@0.2.6:
+    resolution:
+      { integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog== }
+    engines: { node: ">= 6" }
+
+  bser@2.1.1:
+    resolution:
+      { integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ== }
+
+  buffer-from@1.1.2:
+    resolution:
+      { integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ== }
+
   buffer@6.0.3:
     resolution:
       { integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA== }
@@ -1890,6 +2314,11 @@ packages:
       { integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg== }
     engines: { node: ">=6" }
 
+  camelcase@6.3.0:
+    resolution:
+      { integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA== }
+    engines: { node: ">=10" }
+
   caniuse-lite@1.0.30001643:
     resolution:
       { integrity: sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg== }
@@ -1914,6 +2343,11 @@ packages:
       { integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w== }
     engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
 
+  char-regex@1.0.2:
+    resolution:
+      { integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw== }
+    engines: { node: ">=10" }
+
   chardet@0.7.0:
     resolution:
       { integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA== }
@@ -1936,6 +2370,10 @@ packages:
     resolution:
       { integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ== }
 
+  cjs-module-lexer@1.3.1:
+    resolution:
+      { integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q== }
+
   cli-cursor@4.0.0:
     resolution:
       { integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg== }
@@ -1955,6 +2393,11 @@ packages:
     resolution:
       { integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ== }
 
+  cliui@8.0.1:
+    resolution:
+      { integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ== }
+    engines: { node: ">=12" }
+
   clsx@1.2.1:
     resolution:
       { integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg== }
@@ -1964,6 +2407,15 @@ packages:
     resolution:
       { integrity: sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg== }
     engines: { node: ">=6" }
+
+  co@4.6.0:
+    resolution:
+      { integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ== }
+    engines: { iojs: ">= 1.0.0", node: ">= 0.12.0" }
+
+  collect-v8-coverage@1.0.2:
+    resolution:
+      { integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q== }
 
   color-convert@1.9.3:
     resolution:
@@ -2009,6 +2461,10 @@ packages:
       { integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ== }
     engines: { node: ^14.18.0 || >=16.10.0 }
 
+  convert-source-map@2.0.0:
+    resolution:
+      { integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg== }
+
   cookie-es@1.2.1:
     resolution:
       { integrity: sha512-ilTPDuxhZX44BSzzRB58gvSY2UevZKQM9fjisn7Z+NJ92CtSU6kO1+22ZN/agbEJANFjK85EiJJbi/gQv18OXA== }
@@ -2021,6 +2477,12 @@ packages:
     resolution:
       { integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ== }
     engines: { node: ">=0.8" }
+    hasBin: true
+
+  create-jest@29.7.0:
+    resolution:
+      { integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     hasBin: true
 
   cross-fetch@3.1.8:
@@ -2090,6 +2552,15 @@ packages:
       { integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ== }
     engines: { node: ">=0.10" }
 
+  dedent@1.5.3:
+    resolution:
+      { integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ== }
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-eql@4.1.4:
     resolution:
       { integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg== }
@@ -2130,6 +2601,11 @@ packages:
       { integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg== }
     engines: { node: ">=0.10" }
     hasBin: true
+
+  detect-newline@3.1.0:
+    resolution:
+      { integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA== }
+    engines: { node: ">=8" }
 
   detect-node-es@1.1.0:
     resolution:
@@ -2179,9 +2655,20 @@ packages:
     resolution:
       { integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA== }
 
+  ejs@3.1.10:
+    resolution:
+      { integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA== }
+    engines: { node: ">=0.10.0" }
+    hasBin: true
+
   electron-to-chromium@1.5.0:
     resolution:
       { integrity: sha512-Vb3xHHYnLseK8vlMJQKJYXJ++t4u1/qJ3vykuVrVjvdiOEhYyT1AuP4x03G8EnPmYvYOhe9T+dADTmthjRQMkA== }
+
+  emittery@0.13.1:
+    resolution:
+      { integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ== }
+    engines: { node: ">=12" }
 
   emoji-regex@10.3.0:
     resolution:
@@ -2208,6 +2695,10 @@ packages:
       { integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ== }
     engines: { node: ">=8.6" }
 
+  error-ex@1.3.2:
+    resolution:
+      { integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g== }
+
   esbuild@0.21.5:
     resolution:
       { integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw== }
@@ -2229,6 +2720,11 @@ packages:
     resolution:
       { integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg== }
     engines: { node: ">=0.8.0" }
+
+  escape-string-regexp@2.0.0:
+    resolution:
+      { integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w== }
+    engines: { node: ">=8" }
 
   escape-string-regexp@4.0.0:
     resolution:
@@ -2368,6 +2864,16 @@ packages:
       { integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg== }
     engines: { node: ">=16.17" }
 
+  exit@0.1.2:
+    resolution:
+      { integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ== }
+    engines: { node: ">= 0.8.0" }
+
+  expect@29.7.0:
+    resolution:
+      { integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
   extendable-error@0.1.7:
     resolution:
       { integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg== }
@@ -2407,10 +2913,18 @@ packages:
     resolution:
       { integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w== }
 
+  fb-watchman@2.0.2:
+    resolution:
+      { integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA== }
+
   file-entry-cache@6.0.1:
     resolution:
       { integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg== }
     engines: { node: ^10.12.0 || >=12.0.0 }
+
+  filelist@1.0.4:
+    resolution:
+      { integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q== }
 
   fill-range@7.1.1:
     resolution:
@@ -2478,6 +2992,11 @@ packages:
     resolution:
       { integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA== }
 
+  gensync@1.0.0-beta.2:
+    resolution:
+      { integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg== }
+    engines: { node: ">=6.9.0" }
+
   get-caller-file@2.0.5:
     resolution:
       { integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg== }
@@ -2496,6 +3015,11 @@ packages:
     resolution:
       { integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q== }
     engines: { node: ">=6" }
+
+  get-package-type@0.1.0:
+    resolution:
+      { integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q== }
+    engines: { node: ">=8.0.0" }
 
   get-port-please@3.1.2:
     resolution:
@@ -2530,6 +3054,11 @@ packages:
     resolution:
       { integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q== }
     deprecated: Glob versions prior to v9 are no longer supported
+
+  globals@11.12.0:
+    resolution:
+      { integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA== }
+    engines: { node: ">=4" }
 
   globals@13.24.0:
     resolution:
@@ -2592,6 +3121,10 @@ packages:
     resolution:
       { integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw== }
 
+  html-escaper@2.0.2:
+    resolution:
+      { integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg== }
+
   http-shutdown@1.2.2:
     resolution:
       { integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw== }
@@ -2644,6 +3177,12 @@ packages:
       { integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw== }
     engines: { node: ">=6" }
 
+  import-local@3.2.0:
+    resolution:
+      { integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA== }
+    engines: { node: ">=8" }
+    hasBin: true
+
   imurmurhash@0.1.4:
     resolution:
       { integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA== }
@@ -2665,6 +3204,10 @@ packages:
   iron-webcrypto@1.2.1:
     resolution:
       { integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg== }
+
+  is-arrayish@0.2.1:
+    resolution:
+      { integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg== }
 
   is-binary-path@2.1.0:
     resolution:
@@ -2701,6 +3244,11 @@ packages:
     resolution:
       { integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA== }
     engines: { node: ">=18" }
+
+  is-generator-fn@2.1.0:
+    resolution:
+      { integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ== }
+    engines: { node: ">=6" }
 
   is-glob@4.0.3:
     resolution:
@@ -2777,9 +3325,200 @@ packages:
     peerDependencies:
       ws: "*"
 
+  istanbul-lib-coverage@3.2.2:
+    resolution:
+      { integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg== }
+    engines: { node: ">=8" }
+
+  istanbul-lib-instrument@5.2.1:
+    resolution:
+      { integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg== }
+    engines: { node: ">=8" }
+
+  istanbul-lib-instrument@6.0.3:
+    resolution:
+      { integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q== }
+    engines: { node: ">=10" }
+
+  istanbul-lib-report@3.0.1:
+    resolution:
+      { integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw== }
+    engines: { node: ">=10" }
+
+  istanbul-lib-source-maps@4.0.1:
+    resolution:
+      { integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw== }
+    engines: { node: ">=10" }
+
+  istanbul-reports@3.1.7:
+    resolution:
+      { integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g== }
+    engines: { node: ">=8" }
+
   jackspeak@3.4.3:
     resolution:
       { integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw== }
+
+  jake@10.9.2:
+    resolution:
+      { integrity: sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA== }
+    engines: { node: ">=10" }
+    hasBin: true
+
+  jest-changed-files@29.7.0:
+    resolution:
+      { integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-circus@29.7.0:
+    resolution:
+      { integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-cli@29.7.0:
+    resolution:
+      { integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@29.7.0:
+    resolution:
+      { integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+    peerDependencies:
+      "@types/node": "*"
+      ts-node: ">=9.0.0"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@29.7.0:
+    resolution:
+      { integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-docblock@29.7.0:
+    resolution:
+      { integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-each@29.7.0:
+    resolution:
+      { integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-environment-node@29.7.0:
+    resolution:
+      { integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-get-type@29.6.3:
+    resolution:
+      { integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-haste-map@29.7.0:
+    resolution:
+      { integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-leak-detector@29.7.0:
+    resolution:
+      { integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-matcher-utils@29.7.0:
+    resolution:
+      { integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-message-util@29.7.0:
+    resolution:
+      { integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-mock@29.7.0:
+    resolution:
+      { integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-pnp-resolver@1.2.3:
+    resolution:
+      { integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w== }
+    engines: { node: ">=6" }
+    peerDependencies:
+      jest-resolve: "*"
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
+  jest-regex-util@29.6.3:
+    resolution:
+      { integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-resolve-dependencies@29.7.0:
+    resolution:
+      { integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-resolve@29.7.0:
+    resolution:
+      { integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-runner@29.7.0:
+    resolution:
+      { integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-runtime@29.7.0:
+    resolution:
+      { integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-snapshot@29.7.0:
+    resolution:
+      { integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-util@29.7.0:
+    resolution:
+      { integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-validate@29.7.0:
+    resolution:
+      { integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-watcher@29.7.0:
+    resolution:
+      { integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-worker@29.7.0:
+    resolution:
+      { integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest@29.7.0:
+    resolution:
+      { integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw== }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   jiti@1.21.6:
     resolution:
@@ -2809,9 +3548,19 @@ packages:
       { integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA== }
     hasBin: true
 
+  jsesc@2.5.2:
+    resolution:
+      { integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA== }
+    engines: { node: ">=4" }
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution:
       { integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ== }
+
+  json-parse-even-better-errors@2.3.1:
+    resolution:
+      { integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w== }
 
   json-rpc-engine@6.1.0:
     resolution:
@@ -2830,6 +3579,12 @@ packages:
     resolution:
       { integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw== }
 
+  json5@2.2.3:
+    resolution:
+      { integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg== }
+    engines: { node: ">=6" }
+    hasBin: true
+
   jsonfile@4.0.0:
     resolution:
       { integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg== }
@@ -2846,6 +3601,16 @@ packages:
   keyvaluestorage-interface@1.0.0:
     resolution:
       { integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g== }
+
+  kleur@3.0.3:
+    resolution:
+      { integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w== }
+    engines: { node: ">=6" }
+
+  leven@3.1.0:
+    resolution:
+      { integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A== }
+    engines: { node: ">=6" }
 
   levn@0.4.1:
     resolution:
@@ -2931,6 +3696,10 @@ packages:
     resolution:
       { integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ== }
 
+  lodash.memoize@4.1.2:
+    resolution:
+      { integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag== }
+
   lodash.merge@4.6.2:
     resolution:
       { integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ== }
@@ -2965,9 +3734,26 @@ packages:
     resolution:
       { integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g== }
 
+  lru-cache@5.1.1:
+    resolution:
+      { integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w== }
+
   magic-string@0.30.10:
     resolution:
       { integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ== }
+
+  make-dir@4.0.0:
+    resolution:
+      { integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw== }
+    engines: { node: ">=10" }
+
+  make-error@1.3.6:
+    resolution:
+      { integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw== }
+
+  makeerror@1.0.12:
+    resolution:
+      { integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg== }
 
   match-sorter@6.3.4:
     resolution:
@@ -3022,6 +3808,11 @@ packages:
   minimatch@3.1.2:
     resolution:
       { integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw== }
+
+  minimatch@5.1.6:
+    resolution:
+      { integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g== }
+    engines: { node: ">=10" }
 
   minimatch@9.0.5:
     resolution:
@@ -3103,6 +3894,10 @@ packages:
     resolution:
       { integrity: sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw== }
     hasBin: true
+
+  node-int64@0.4.0:
+    resolution:
+      { integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw== }
 
   node-releases@2.0.18:
     resolution:
@@ -3234,6 +4029,11 @@ packages:
     resolution:
       { integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g== }
     engines: { node: ">=6" }
+
+  parse-json@5.2.0:
+    resolution:
+      { integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg== }
+    engines: { node: ">=8" }
 
   path-exists@4.0.0:
     resolution:
@@ -3504,6 +4304,11 @@ packages:
     resolution:
       { integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q== }
 
+  prompts@2.4.2:
+    resolution:
+      { integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q== }
+    engines: { node: ">= 6" }
+
   prop-types@15.8.1:
     resolution:
       { integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg== }
@@ -3520,6 +4325,10 @@ packages:
     resolution:
       { integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg== }
     engines: { node: ">=6" }
+
+  pure-rand@6.1.0:
+    resolution:
+      { integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA== }
 
   qrcode@1.5.3:
     resolution:
@@ -3687,6 +4496,11 @@ packages:
     resolution:
       { integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg== }
 
+  resolve-cwd@3.0.0:
+    resolution:
+      { integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg== }
+    engines: { node: ">=8" }
+
   resolve-from@4.0.0:
     resolution:
       { integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g== }
@@ -3696,6 +4510,11 @@ packages:
     resolution:
       { integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw== }
     engines: { node: ">=8" }
+
+  resolve.exports@2.0.2:
+    resolution:
+      { integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg== }
+    engines: { node: ">=10" }
 
   resolve@1.22.8:
     resolution:
@@ -3758,6 +4577,11 @@ packages:
     resolution:
       { integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ== }
 
+  semver@6.3.1:
+    resolution:
+      { integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA== }
+    hasBin: true
+
   semver@7.6.3:
     resolution:
       { integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A== }
@@ -3806,6 +4630,10 @@ packages:
       { integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw== }
     engines: { node: ">=14" }
 
+  sisteransi@1.0.5:
+    resolution:
+      { integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg== }
+
   slash@3.0.0:
     resolution:
       { integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q== }
@@ -3834,6 +4662,15 @@ packages:
       { integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg== }
     engines: { node: ">=0.10.0" }
 
+  source-map-support@0.5.13:
+    resolution:
+      { integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w== }
+
+  source-map@0.6.1:
+    resolution:
+      { integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g== }
+    engines: { node: ">=0.10.0" }
+
   source-map@0.8.0-beta.0:
     resolution:
       { integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA== }
@@ -3857,6 +4694,11 @@ packages:
     resolution:
       { integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g== }
 
+  stack-utils@2.0.6:
+    resolution:
+      { integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ== }
+    engines: { node: ">=10" }
+
   stackback@0.0.2:
     resolution:
       { integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw== }
@@ -3878,6 +4720,11 @@ packages:
     resolution:
       { integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q== }
     engines: { node: ">=0.6.19" }
+
+  string-length@4.0.2:
+    resolution:
+      { integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ== }
+    engines: { node: ">=10" }
 
   string-width@4.2.3:
     resolution:
@@ -3912,6 +4759,11 @@ packages:
     resolution:
       { integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA== }
     engines: { node: ">=4" }
+
+  strip-bom@4.0.0:
+    resolution:
+      { integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w== }
+    engines: { node: ">=8" }
 
   strip-final-newline@2.0.0:
     resolution:
@@ -3953,6 +4805,11 @@ packages:
       { integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw== }
     engines: { node: ">=8" }
 
+  supports-color@8.1.1:
+    resolution:
+      { integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q== }
+    engines: { node: ">=10" }
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution:
       { integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w== }
@@ -3981,6 +4838,11 @@ packages:
   term-size@2.2.1:
     resolution:
       { integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg== }
+    engines: { node: ">=8" }
+
+  test-exclude@6.0.0:
+    resolution:
+      { integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w== }
     engines: { node: ">=8" }
 
   text-table@0.2.0:
@@ -4019,6 +4881,15 @@ packages:
       { integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw== }
     engines: { node: ">=0.6.0" }
 
+  tmpl@1.0.5:
+    resolution:
+      { integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw== }
+
+  to-fast-properties@2.0.0:
+    resolution:
+      { integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog== }
+    engines: { node: ">=4" }
+
   to-regex-range@5.0.1:
     resolution:
       { integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ== }
@@ -4056,6 +4927,31 @@ packages:
     resolution:
       { integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ== }
     engines: { node: ">=8" }
+
+  ts-jest@29.2.3:
+    resolution:
+      { integrity: sha512-yCcfVdiBFngVz9/keHin9EnsrQtQtEu3nRykNy9RVp+FiPFFbPJ3Sg6Qg4+TkmH0vMP5qsTKgXSsk80HRwvdgQ== }
+    engines: { node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@babel/core": ">=7.0.0-beta.0 <8"
+      "@jest/transform": ^29.0.0
+      "@jest/types": ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: "*"
+      jest: ^29.0.0
+      typescript: ">=4.3 <6"
+    peerDependenciesMeta:
+      "@babel/core":
+        optional: true
+      "@jest/transform":
+        optional: true
+      "@jest/types":
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
 
   tslib@1.14.1:
     resolution:
@@ -4139,6 +5035,11 @@ packages:
   type-fest@0.20.2:
     resolution:
       { integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ== }
+    engines: { node: ">=10" }
+
+  type-fest@0.21.3:
+    resolution:
+      { integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w== }
     engines: { node: ">=10" }
 
   typedarray-to-buffer@3.1.5:
@@ -4292,6 +5193,11 @@ packages:
       { integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA== }
     hasBin: true
 
+  v8-to-istanbul@9.3.0:
+    resolution:
+      { integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA== }
+    engines: { node: ">=10.12.0" }
+
   valtio@1.11.2:
     resolution:
       { integrity: sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw== }
@@ -4395,6 +5301,10 @@ packages:
       typescript:
         optional: true
 
+  walker@1.0.8:
+    resolution:
+      { integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ== }
+
   webauthn-p256@0.0.5:
     resolution:
       { integrity: sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg== }
@@ -4470,6 +5380,11 @@ packages:
     resolution:
       { integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ== }
 
+  write-file-atomic@4.0.2:
+    resolution:
+      { integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg== }
+    engines: { node: ^12.13.0 || ^14.15.0 || >=16.0.0 }
+
   ws@7.5.10:
     resolution:
       { integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ== }
@@ -4518,9 +5433,18 @@ packages:
     resolution:
       { integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ== }
 
+  y18n@5.0.8:
+    resolution:
+      { integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA== }
+    engines: { node: ">=10" }
+
   yallist@2.1.2:
     resolution:
       { integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A== }
+
+  yallist@3.1.1:
+    resolution:
+      { integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g== }
 
   yaml@2.4.5:
     resolution:
@@ -4533,10 +5457,20 @@ packages:
       { integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ== }
     engines: { node: ">=6" }
 
+  yargs-parser@21.1.1:
+    resolution:
+      { integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw== }
+    engines: { node: ">=12" }
+
   yargs@15.4.1:
     resolution:
       { integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A== }
     engines: { node: ">=8" }
+
+  yargs@17.7.2:
+    resolution:
+      { integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w== }
+    engines: { node: ">=12" }
 
   yocto-queue@0.1.0:
     resolution:
@@ -4577,6 +5511,11 @@ snapshots:
 
   "@alloc/quick-lru@5.2.0": {}
 
+  "@ampproject/remapping@2.3.0":
+    dependencies:
+      "@jridgewell/gen-mapping": 0.3.5
+      "@jridgewell/trace-mapping": 0.3.25
+
   "@apollo/client@3.11.1(@types/react@18.3.3)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
       "@graphql-typed-document-node/core": 3.2.0(graphql@16.9.0)
@@ -4600,9 +5539,216 @@ snapshots:
     transitivePeerDependencies:
       - "@types/react"
 
+  "@babel/code-frame@7.24.7":
+    dependencies:
+      "@babel/highlight": 7.24.7
+      picocolors: 1.0.1
+
+  "@babel/compat-data@7.24.9": {}
+
+  "@babel/core@7.24.9":
+    dependencies:
+      "@ampproject/remapping": 2.3.0
+      "@babel/code-frame": 7.24.7
+      "@babel/generator": 7.24.10
+      "@babel/helper-compilation-targets": 7.24.8
+      "@babel/helper-module-transforms": 7.24.9(@babel/core@7.24.9)
+      "@babel/helpers": 7.24.8
+      "@babel/parser": 7.24.8
+      "@babel/template": 7.24.7
+      "@babel/traverse": 7.24.8
+      "@babel/types": 7.24.9
+      convert-source-map: 2.0.0
+      debug: 4.3.5
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/generator@7.24.10":
+    dependencies:
+      "@babel/types": 7.24.9
+      "@jridgewell/gen-mapping": 0.3.5
+      "@jridgewell/trace-mapping": 0.3.25
+      jsesc: 2.5.2
+
+  "@babel/helper-compilation-targets@7.24.8":
+    dependencies:
+      "@babel/compat-data": 7.24.9
+      "@babel/helper-validator-option": 7.24.8
+      browserslist: 4.23.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  "@babel/helper-environment-visitor@7.24.7":
+    dependencies:
+      "@babel/types": 7.24.9
+
+  "@babel/helper-function-name@7.24.7":
+    dependencies:
+      "@babel/template": 7.24.7
+      "@babel/types": 7.24.9
+
+  "@babel/helper-hoist-variables@7.24.7":
+    dependencies:
+      "@babel/types": 7.24.9
+
+  "@babel/helper-module-imports@7.24.7":
+    dependencies:
+      "@babel/traverse": 7.24.8
+      "@babel/types": 7.24.9
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-module-transforms@7.24.9(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-environment-visitor": 7.24.7
+      "@babel/helper-module-imports": 7.24.7
+      "@babel/helper-simple-access": 7.24.7
+      "@babel/helper-split-export-declaration": 7.24.7
+      "@babel/helper-validator-identifier": 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-plugin-utils@7.24.8": {}
+
+  "@babel/helper-simple-access@7.24.7":
+    dependencies:
+      "@babel/traverse": 7.24.8
+      "@babel/types": 7.24.9
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-split-export-declaration@7.24.7":
+    dependencies:
+      "@babel/types": 7.24.9
+
+  "@babel/helper-string-parser@7.24.8": {}
+
+  "@babel/helper-validator-identifier@7.24.7": {}
+
+  "@babel/helper-validator-option@7.24.8": {}
+
+  "@babel/helpers@7.24.8":
+    dependencies:
+      "@babel/template": 7.24.7
+      "@babel/types": 7.24.9
+
+  "@babel/highlight@7.24.7":
+    dependencies:
+      "@babel/helper-validator-identifier": 7.24.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.0.1
+
+  "@babel/parser@7.24.8":
+    dependencies:
+      "@babel/types": 7.24.9
+
+  "@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
+  "@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.9)":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/helper-plugin-utils": 7.24.8
+
   "@babel/runtime@7.24.8":
     dependencies:
       regenerator-runtime: 0.14.1
+
+  "@babel/template@7.24.7":
+    dependencies:
+      "@babel/code-frame": 7.24.7
+      "@babel/parser": 7.24.8
+      "@babel/types": 7.24.9
+
+  "@babel/traverse@7.24.8":
+    dependencies:
+      "@babel/code-frame": 7.24.7
+      "@babel/generator": 7.24.10
+      "@babel/helper-environment-visitor": 7.24.7
+      "@babel/helper-function-name": 7.24.7
+      "@babel/helper-hoist-variables": 7.24.7
+      "@babel/helper-split-export-declaration": 7.24.7
+      "@babel/parser": 7.24.8
+      "@babel/types": 7.24.9
+      debug: 4.3.5
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/types@7.24.9":
+    dependencies:
+      "@babel/helper-string-parser": 7.24.8
+      "@babel/helper-validator-identifier": 7.24.7
+      to-fast-properties: 2.0.0
+
+  "@bcoe/v8-coverage@0.2.3": {}
 
   "@changesets/apply-release-plan@7.0.4":
     dependencies:
@@ -4989,6 +6135,8 @@ snapshots:
     dependencies:
       graphql: 16.9.0
 
+  "@helixbridge/helixconf@1.1.0": {}
+
   "@humanwhocodes/config-array@0.11.14":
     dependencies:
       "@humanwhocodes/object-schema": 2.0.3
@@ -5010,9 +6158,177 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  "@istanbuljs/load-nyc-config@1.1.0":
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.14.1
+      resolve-from: 5.0.0
+
+  "@istanbuljs/schema@0.1.3": {}
+
+  "@jest/console@29.7.0":
+    dependencies:
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
+  "@jest/core@29.7.0":
+    dependencies:
+      "@jest/console": 29.7.0
+      "@jest/reporters": 29.7.0
+      "@jest/test-result": 29.7.0
+      "@jest/transform": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.14.12)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.7
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  "@jest/environment@29.7.0":
+    dependencies:
+      "@jest/fake-timers": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      jest-mock: 29.7.0
+
+  "@jest/expect-utils@29.7.0":
+    dependencies:
+      jest-get-type: 29.6.3
+
+  "@jest/expect@29.7.0":
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  "@jest/fake-timers@29.7.0":
+    dependencies:
+      "@jest/types": 29.6.3
+      "@sinonjs/fake-timers": 10.3.0
+      "@types/node": 20.14.12
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  "@jest/globals@29.7.0":
+    dependencies:
+      "@jest/environment": 29.7.0
+      "@jest/expect": 29.7.0
+      "@jest/types": 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  "@jest/reporters@29.7.0":
+    dependencies:
+      "@bcoe/v8-coverage": 0.2.3
+      "@jest/console": 29.7.0
+      "@jest/test-result": 29.7.0
+      "@jest/transform": 29.7.0
+      "@jest/types": 29.6.3
+      "@jridgewell/trace-mapping": 0.3.25
+      "@types/node": 20.14.12
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.2
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.7
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   "@jest/schemas@29.6.3":
     dependencies:
       "@sinclair/typebox": 0.27.8
+
+  "@jest/source-map@29.6.3":
+    dependencies:
+      "@jridgewell/trace-mapping": 0.3.25
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  "@jest/test-result@29.7.0":
+    dependencies:
+      "@jest/console": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/istanbul-lib-coverage": 2.0.6
+      collect-v8-coverage: 1.0.2
+
+  "@jest/test-sequencer@29.7.0":
+    dependencies:
+      "@jest/test-result": 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
+
+  "@jest/transform@29.7.0":
+    dependencies:
+      "@babel/core": 7.24.9
+      "@jest/types": 29.6.3
+      "@jridgewell/trace-mapping": 0.3.25
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      micromatch: 4.0.7
+      pirates: 4.0.6
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  "@jest/types@29.6.3":
+    dependencies:
+      "@jest/schemas": 29.6.3
+      "@types/istanbul-lib-coverage": 2.0.6
+      "@types/istanbul-reports": 3.0.4
+      "@types/node": 20.14.12
+      "@types/yargs": 17.0.32
+      chalk: 4.1.2
 
   "@jridgewell/gen-mapping@0.3.5":
     dependencies:
@@ -5381,6 +6697,14 @@ snapshots:
 
   "@sinclair/typebox@0.27.8": {}
 
+  "@sinonjs/commons@3.0.1":
+    dependencies:
+      type-detect: 4.0.8
+
+  "@sinonjs/fake-timers@10.3.0":
+    dependencies:
+      "@sinonjs/commons": 3.0.1
+
   "@stablelib/aead@1.0.1": {}
 
   "@stablelib/binary@1.0.1":
@@ -5536,11 +6860,51 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
+  "@types/babel__core@7.20.5":
+    dependencies:
+      "@babel/parser": 7.24.8
+      "@babel/types": 7.24.9
+      "@types/babel__generator": 7.6.8
+      "@types/babel__template": 7.4.4
+      "@types/babel__traverse": 7.20.6
+
+  "@types/babel__generator@7.6.8":
+    dependencies:
+      "@babel/types": 7.24.9
+
+  "@types/babel__template@7.4.4":
+    dependencies:
+      "@babel/parser": 7.24.8
+      "@babel/types": 7.24.9
+
+  "@types/babel__traverse@7.20.6":
+    dependencies:
+      "@babel/types": 7.24.9
+
   "@types/debug@4.1.12":
     dependencies:
       "@types/ms": 0.7.34
 
   "@types/estree@1.0.5": {}
+
+  "@types/graceful-fs@4.1.9":
+    dependencies:
+      "@types/node": 20.14.12
+
+  "@types/istanbul-lib-coverage@2.0.6": {}
+
+  "@types/istanbul-lib-report@3.0.3":
+    dependencies:
+      "@types/istanbul-lib-coverage": 2.0.6
+
+  "@types/istanbul-reports@3.0.4":
+    dependencies:
+      "@types/istanbul-lib-report": 3.0.3
+
+  "@types/jest@29.5.12":
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
 
   "@types/ms@0.7.34": {}
 
@@ -5567,7 +6931,15 @@ snapshots:
 
   "@types/semver@7.5.8": {}
 
+  "@types/stack-utils@2.0.3": {}
+
   "@types/trusted-types@2.0.7": {}
+
+  "@types/yargs-parser@21.0.3": {}
+
+  "@types/yargs@17.0.32":
+    dependencies:
+      "@types/yargs-parser": 21.0.3
 
   "@typescript-eslint/eslint-plugin@7.17.0(@typescript-eslint/parser@7.17.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)":
     dependencies:
@@ -6233,6 +7605,10 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-escapes@6.2.1: {}
 
   ansi-regex@5.0.1: {}
@@ -6274,6 +7650,8 @@ snapshots:
     dependencies:
       tslib: 2.6.3
 
+  async@3.2.5: {}
+
   atomic-sleep@1.0.0: {}
 
   autoprefixer@10.4.19(postcss@8.4.39):
@@ -6285,6 +7663,58 @@ snapshots:
       picocolors: 1.0.1
       postcss: 8.4.39
       postcss-value-parser: 4.2.0
+
+  babel-jest@29.7.0(@babel/core@7.24.9):
+    dependencies:
+      "@babel/core": 7.24.9
+      "@jest/transform": 29.7.0
+      "@types/babel__core": 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.24.9)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-istanbul@6.1.1:
+    dependencies:
+      "@babel/helper-plugin-utils": 7.24.8
+      "@istanbuljs/load-nyc-config": 1.1.0
+      "@istanbuljs/schema": 0.1.3
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-jest-hoist@29.6.3:
+    dependencies:
+      "@babel/template": 7.24.7
+      "@babel/types": 7.24.9
+      "@types/babel__core": 7.20.5
+      "@types/babel__traverse": 7.20.6
+
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.9):
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/plugin-syntax-async-generators": 7.8.4(@babel/core@7.24.9)
+      "@babel/plugin-syntax-bigint": 7.8.3(@babel/core@7.24.9)
+      "@babel/plugin-syntax-class-properties": 7.12.13(@babel/core@7.24.9)
+      "@babel/plugin-syntax-import-meta": 7.10.4(@babel/core@7.24.9)
+      "@babel/plugin-syntax-json-strings": 7.8.3(@babel/core@7.24.9)
+      "@babel/plugin-syntax-logical-assignment-operators": 7.10.4(@babel/core@7.24.9)
+      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.24.9)
+      "@babel/plugin-syntax-numeric-separator": 7.10.4(@babel/core@7.24.9)
+      "@babel/plugin-syntax-object-rest-spread": 7.8.3(@babel/core@7.24.9)
+      "@babel/plugin-syntax-optional-catch-binding": 7.8.3(@babel/core@7.24.9)
+      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.24.9)
+      "@babel/plugin-syntax-top-level-await": 7.14.5(@babel/core@7.24.9)
+
+  babel-preset-jest@29.6.3(@babel/core@7.24.9):
+    dependencies:
+      "@babel/core": 7.24.9
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.9)
 
   balanced-match@1.0.2: {}
 
@@ -6318,6 +7748,16 @@ snapshots:
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.2)
 
+  bs-logger@0.2.6:
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
+  buffer-from@1.1.2: {}
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -6335,6 +7775,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001643: {}
 
@@ -6361,6 +7803,8 @@ snapshots:
 
   chalk@5.3.0: {}
 
+  char-regex@1.0.2: {}
+
   chardet@0.7.0: {}
 
   check-error@1.0.3:
@@ -6385,6 +7829,8 @@ snapshots:
     dependencies:
       consola: 3.2.3
 
+  cjs-module-lexer@1.3.1: {}
+
   cli-cursor@4.0.0:
     dependencies:
       restore-cursor: 4.0.0
@@ -6406,9 +7852,19 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@1.2.1: {}
 
   clsx@2.1.0: {}
+
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.2: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -6434,6 +7890,8 @@ snapshots:
 
   consola@3.2.3: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-es@1.2.1: {}
 
   copy-to-clipboard@3.3.3:
@@ -6441,6 +7899,21 @@ snapshots:
       toggle-selection: 1.0.6
 
   crc-32@1.2.2: {}
+
+  create-jest@29.7.0(@types/node@20.14.12):
+    dependencies:
+      "@jest/types": 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.14.12)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - "@types/node"
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   cross-fetch@3.1.8:
     dependencies:
@@ -6482,6 +7955,8 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  dedent@1.5.3: {}
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.0.8
@@ -6501,6 +7976,8 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-libc@1.0.3: {}
+
+  detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
 
@@ -6536,7 +8013,13 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.2
+
   electron-to-chromium@1.5.0: {}
+
+  emittery@0.13.1: {}
 
   emoji-regex@10.3.0: {}
 
@@ -6554,6 +8037,10 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  error-ex@1.3.2:
+    dependencies:
+      is-arrayish: 0.2.1
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -6611,6 +8098,8 @@ snapshots:
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -6776,6 +8265,16 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  exit@0.1.2: {}
+
+  expect@29.7.0:
+    dependencies:
+      "@jest/expect-utils": 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
   extendable-error@0.1.7: {}
 
   external-editor@3.1.0:
@@ -6806,9 +8305,17 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
+
+  filelist@1.0.4:
+    dependencies:
+      minimatch: 5.1.6
 
   fill-range@7.1.1:
     dependencies:
@@ -6865,6 +8372,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.2.0: {}
@@ -6872,6 +8381,8 @@ snapshots:
   get-func-name@2.0.2: {}
 
   get-nonce@1.0.1: {}
+
+  get-package-type@0.1.0: {}
 
   get-port-please@3.1.2: {}
 
@@ -6904,6 +8415,8 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  globals@11.12.0: {}
 
   globals@13.24.0:
     dependencies:
@@ -6963,6 +8476,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-escaper@2.0.2: {}
+
   http-shutdown@1.2.2: {}
 
   human-id@1.0.2: {}
@@ -6990,6 +8505,11 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
   imurmurhash@0.1.4: {}
 
   inflight@1.0.6:
@@ -7004,6 +8524,8 @@ snapshots:
       loose-envify: 1.4.0
 
   iron-webcrypto@1.2.1: {}
+
+  is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -7024,6 +8546,8 @@ snapshots:
   is-fullwidth-code-point@5.0.0:
     dependencies:
       get-east-asian-width: 1.2.0
+
+  is-generator-fn@2.1.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -7074,11 +8598,367 @@ snapshots:
     dependencies:
       ws: 8.17.1
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-instrument@5.2.1:
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/parser": 7.24.8
+      "@istanbuljs/schema": 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/parser": 7.24.8
+      "@istanbuljs/schema": 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.3.5
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.1.7:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jackspeak@3.4.3:
     dependencies:
       "@isaacs/cliui": 8.0.2
     optionalDependencies:
       "@pkgjs/parseargs": 0.11.0
+
+  jake@10.9.2:
+    dependencies:
+      async: 3.2.5
+      chalk: 4.1.2
+      filelist: 1.0.4
+      minimatch: 3.1.2
+
+  jest-changed-files@29.7.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+
+  jest-circus@29.7.0:
+    dependencies:
+      "@jest/environment": 29.7.0
+      "@jest/expect": 29.7.0
+      "@jest/test-result": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.5.3
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@29.7.0(@types/node@20.14.12):
+    dependencies:
+      "@jest/core": 29.7.0
+      "@jest/test-result": 29.7.0
+      "@jest/types": 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.14.12)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.14.12)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - "@types/node"
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-config@29.7.0(@types/node@20.14.12):
+    dependencies:
+      "@babel/core": 7.24.9
+      "@jest/test-sequencer": 29.7.0
+      "@jest/types": 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.9)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.7
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      "@types/node": 20.14.12
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@29.7.0:
+    dependencies:
+      "@jest/types": 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
+
+  jest-environment-node@29.7.0:
+    dependencies:
+      "@jest/environment": 29.7.0
+      "@jest/fake-timers": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-haste-map@29.7.0:
+    dependencies:
+      "@jest/types": 29.6.3
+      "@types/graceful-fs": 4.1.9
+      "@types/node": 20.14.12
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      micromatch: 4.0.7
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  jest-leak-detector@29.7.0:
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      "@babel/code-frame": 7.24.7
+      "@jest/types": 29.6.3
+      "@types/stack-utils": 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.7
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@29.7.0:
+    dependencies:
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      jest-util: 29.7.0
+
+  jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    optionalDependencies:
+      jest-resolve: 29.7.0
+
+  jest-regex-util@29.6.3: {}
+
+  jest-resolve-dependencies@29.7.0:
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.8
+      resolve.exports: 2.0.2
+      slash: 3.0.0
+
+  jest-runner@29.7.0:
+    dependencies:
+      "@jest/console": 29.7.0
+      "@jest/environment": 29.7.0
+      "@jest/test-result": 29.7.0
+      "@jest/transform": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@29.7.0:
+    dependencies:
+      "@jest/environment": 29.7.0
+      "@jest/fake-timers": 29.7.0
+      "@jest/globals": 29.7.0
+      "@jest/source-map": 29.6.3
+      "@jest/test-result": 29.7.0
+      "@jest/transform": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      chalk: 4.1.2
+      cjs-module-lexer: 1.3.1
+      collect-v8-coverage: 1.0.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@29.7.0:
+    dependencies:
+      "@babel/core": 7.24.9
+      "@babel/generator": 7.24.10
+      "@babel/plugin-syntax-jsx": 7.24.7(@babel/core@7.24.9)
+      "@babel/plugin-syntax-typescript": 7.24.7(@babel/core@7.24.9)
+      "@babel/types": 7.24.9
+      "@jest/expect-utils": 29.7.0
+      "@jest/transform": 29.7.0
+      "@jest/types": 29.6.3
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.9)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-util@29.7.0:
+    dependencies:
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+
+  jest-validate@29.7.0:
+    dependencies:
+      "@jest/types": 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
+  jest-watcher@29.7.0:
+    dependencies:
+      "@jest/test-result": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 20.14.12
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
+
+  jest-worker@29.7.0:
+    dependencies:
+      "@types/node": 20.14.12
+      jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@20.14.12):
+    dependencies:
+      "@jest/core": 29.7.0
+      "@jest/types": 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.14.12)
+    transitivePeerDependencies:
+      - "@types/node"
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jiti@1.21.6: {}
 
@@ -7097,7 +8977,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@2.5.2: {}
+
   json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
 
   json-rpc-engine@6.1.0:
     dependencies:
@@ -7109,6 +8993,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -7125,6 +9011,10 @@ snapshots:
       json-buffer: 3.0.1
 
   keyvaluestorage-interface@1.0.0: {}
+
+  kleur@3.0.3: {}
+
+  leven@3.1.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -7232,6 +9122,8 @@ snapshots:
 
   lodash.isequal@4.5.0: {}
 
+  lodash.memoize@4.1.2: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.sortby@4.7.0: {}
@@ -7261,9 +9153,23 @@ snapshots:
       pseudomap: 1.0.2
       yallist: 2.1.2
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   magic-string@0.30.10:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.0
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.6.3
+
+  make-error@1.3.6: {}
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
 
   match-sorter@6.3.4:
     dependencies:
@@ -7298,6 +9204,10 @@ snapshots:
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
+
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.1
 
   minimatch@9.0.5:
     dependencies:
@@ -7352,6 +9262,8 @@ snapshots:
   node-forge@1.3.1: {}
 
   node-gyp-build@4.8.1: {}
+
+  node-int64@0.4.0: {}
 
   node-releases@2.0.18: {}
 
@@ -7448,6 +9360,13 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      "@babel/code-frame": 7.24.7
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   path-exists@4.0.0: {}
 
@@ -7593,6 +9512,11 @@ snapshots:
 
   process-warning@1.0.0: {}
 
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7604,6 +9528,8 @@ snapshots:
   pseudomap@1.0.2: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   qrcode@1.5.3:
     dependencies:
@@ -7741,9 +9667,15 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve.exports@2.0.2: {}
 
   resolve@1.22.8:
     dependencies:
@@ -7806,6 +9738,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  semver@6.3.1: {}
+
   semver@7.6.3: {}
 
   set-blocking@2.0.0: {}
@@ -7833,6 +9767,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sisteransi@1.0.5: {}
+
   slash@3.0.0: {}
 
   slice-ansi@5.0.0:
@@ -7853,6 +9789,13 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
@@ -7868,6 +9811,10 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
   std-env@3.7.0: {}
@@ -7877,6 +9824,11 @@ snapshots:
   strict-uri-encode@2.0.0: {}
 
   string-argv@0.3.2: {}
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
 
   string-width@4.2.3:
     dependencies:
@@ -7910,6 +9862,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-bom@4.0.0: {}
+
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@3.0.0: {}
@@ -7937,6 +9891,10 @@ snapshots:
       has-flag: 3.0.0
 
   supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
 
@@ -7977,6 +9935,12 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  test-exclude@6.0.0:
+    dependencies:
+      "@istanbuljs/schema": 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -8001,6 +9965,10 @@ snapshots:
     dependencies:
       os-tmpdir: 1.0.2
 
+  tmpl@1.0.5: {}
+
+  to-fast-properties@2.0.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -8024,6 +9992,25 @@ snapshots:
   ts-invariant@0.10.3:
     dependencies:
       tslib: 2.6.3
+
+  ts-jest@29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0)(typescript@5.5.4):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.14.12)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.3
+      typescript: 5.5.4
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      "@babel/core": 7.24.9
+      "@jest/transform": 29.7.0
+      "@jest/types": 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.9)
 
   tslib@1.14.1: {}
 
@@ -8091,6 +10078,8 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-fest@0.20.2: {}
+
+  type-fest@0.21.3: {}
 
   typedarray-to-buffer@3.1.5:
     dependencies:
@@ -8183,6 +10172,12 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@9.0.1: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      "@jridgewell/trace-mapping": 0.3.25
+      "@types/istanbul-lib-coverage": 2.0.6
+      convert-source-map: 2.0.0
 
   valtio@1.11.2(@types/react@18.3.3)(react@18.3.1):
     dependencies:
@@ -8323,6 +10318,10 @@ snapshots:
       - utf-8-validate
       - zod
 
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
   webauthn-p256@0.0.5:
     dependencies:
       "@noble/curves": 1.4.2
@@ -8391,6 +10390,11 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  write-file-atomic@4.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+
   ws@7.5.10: {}
 
   ws@8.13.0: {}
@@ -8401,7 +10405,11 @@ snapshots:
 
   y18n@4.0.3: {}
 
+  y18n@5.0.8: {}
+
   yallist@2.1.2: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.4.5: {}
 
@@ -8409,6 +10417,8 @@ snapshots:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
+
+  yargs-parser@21.1.1: {}
 
   yargs@15.4.1:
     dependencies:
@@ -8423,6 +10433,16 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.2
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds Jest configuration, Jest presets package, Jest tests, and updates ESLint and TypeScript configurations.

### Detailed summary
- Added Jest configuration to `chains` package
- Included `@helixbridge/jest-presets` package
- Implemented Jest tests for `getChainByIdOrNetwork` and `getChains`
- Updated ESLint and TypeScript configurations

> The following files were skipped due to too many changes: `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->