### PR TITLE
Fix indexer token symbol case

### DIFF
--- a/apps/web/src/components/explorer/explorer-table.tsx
+++ b/apps/web/src/components/explorer/explorer-table.tsx
@@ -84,7 +84,9 @@ function getColumns(isLg = false): ColumnType<TData>[] {
       title: "Amount",
       key: "amount",
       render: (row) => {
-        const token = getChainConfig(row.fromChain)?.tokens.find(({ symbol }) => symbol === row.sendToken);
+        const token = getChainConfig(row.fromChain)?.tokens.find(
+          ({ symbol }) => symbol.toUpperCase() === row.sendToken.toUpperCase(),
+        );
         return token ? (
           <div className="gap-medium flex items-center">
             <img

--- a/apps/web/src/components/history/history-details.tsx
+++ b/apps/web/src/components/history/history-details.tsx
@@ -25,7 +25,7 @@ export default function HistoryDetails({ data: propsData }: Props) {
 
   const sourceChain = getChainConfig(data?.fromChain);
   const targetChain = getChainConfig(data?.toChain);
-  const sourceToken = sourceChain?.tokens.find(({ symbol }) => symbol === data?.sendToken);
+  const sourceToken = sourceChain?.tokens.find(({ symbol }) => symbol.toUpperCase() === data?.sendToken?.toUpperCase());
 
   return (
     <div className="relative overflow-x-auto pb-2">

--- a/apps/web/src/components/history/history-table.tsx
+++ b/apps/web/src/components/history/history-table.tsx
@@ -23,7 +23,9 @@ const columns: ColumnType<TData>[] = [
     title: "Value",
     key: "value",
     render: (row) => {
-      const token = getChainConfig(row.fromChain)?.tokens.find(({ symbol }) => symbol === row.sendToken);
+      const token = getChainConfig(row.fromChain)?.tokens.find(
+        ({ symbol }) => symbol.toUpperCase() === row.sendToken.toUpperCase(),
+      );
       return (
         <span className="truncate">
           {token ? `${formatBalance(BigInt(row.sendAmount), token.decimals)} ${token.symbol}` : "-"}

--- a/apps/web/src/components/record-detail.tsx
+++ b/apps/web/src/components/record-detail.tsx
@@ -39,8 +39,12 @@ export default function RecordDetail(props: Props) {
     const category = record?.historyRecordById?.bridge;
     const sourceChain = getChainConfig(record?.historyRecordById?.fromChain);
     const targetChain = getChainConfig(record?.historyRecordById?.toChain);
-    const sourceToken = sourceChain?.tokens.find((t) => t.symbol === record?.historyRecordById?.sendToken);
-    const targetToken = targetChain?.tokens.find((t) => t.symbol === record?.historyRecordById?.recvToken);
+    const sourceToken = sourceChain?.tokens.find(
+      (t) => t.symbol.toUpperCase() === record?.historyRecordById?.sendToken.toUpperCase(),
+    );
+    const targetToken = targetChain?.tokens.find(
+      (t) => t.symbol.toUpperCase() === record?.historyRecordById?.recvToken.toUpperCase(),
+    );
 
     if (category) {
       return bridgeFactory({ category, sourceChain, targetChain, sourceToken, targetToken });

--- a/apps/web/src/components/records-table.tsx
+++ b/apps/web/src/components/records-table.tsx
@@ -62,7 +62,7 @@ export default function RecordsTable({
       key: "amount",
       title: <Title>Amount</Title>,
       render: ({ fromChain, sendAmount, sendToken }) => {
-        const token = getChainConfig(fromChain)?.tokens.find((t) => t.symbol === sendToken);
+        const token = getChainConfig(fromChain)?.tokens.find((t) => t.symbol.toUpperCase() === sendToken.toUpperCase());
         return token ? (
           <div className="gap-medium flex items-center justify-start">
             <img width={32} height={32} alt="Token" src={getTokenLogoSrc(token.logo)} className="rounded-full" />

--- a/apps/web/src/components/token-transfer.tsx
+++ b/apps/web/src/components/token-transfer.tsx
@@ -51,7 +51,7 @@ function Item({
   amount: bigint;
 }) {
   const chainConfig = getChainConfig(chain);
-  const token = chainConfig?.tokens.find((t) => t.symbol === symbol);
+  const token = chainConfig?.tokens.find((t) => t.symbol.toUpperCase() === symbol.toUpperCase());
 
   return token && chainConfig ? (
     <div className="gap-medium flex items-center">

--- a/apps/web/src/components/transaction-fee.tsx
+++ b/apps/web/src/components/transaction-fee.tsx
@@ -7,7 +7,9 @@ interface Props {
 }
 
 export default function TransactionFee({ record }: Props) {
-  const token = getChainConfig(record?.fromChain)?.tokens.find(({ symbol }) => symbol === record?.feeToken);
+  const token = getChainConfig(record?.fromChain)?.tokens.find(
+    ({ symbol }) => symbol.toUpperCase() === record?.feeToken.toUpperCase(),
+  );
 
   return (
     <span className="text-sm font-medium text-white">

--- a/apps/web/src/components/transaction-value.tsx
+++ b/apps/web/src/components/transaction-value.tsx
@@ -7,7 +7,9 @@ interface Props {
 }
 
 export default function TransactionValue({ record }: Props) {
-  const token = getChainConfig(record?.fromChain)?.tokens.find(({ symbol }) => symbol === record?.sendToken);
+  const token = getChainConfig(record?.fromChain)?.tokens.find(
+    ({ symbol }) => symbol.toUpperCase() === record?.sendToken.toUpperCase(),
+  );
 
   return (
     <span className="text-sm font-medium text-white">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR standardizes token comparison by converting symbols to uppercase for consistency across components.

### Detailed summary
- Converted token symbols to uppercase for consistency in token comparison across components.
- Updated token symbol comparisons in multiple components to use `toUpperCase()` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->