### PR TITLE
Disable tooltip from user account

### DIFF
--- a/apps/web/src/components/pretty-address.tsx
+++ b/apps/web/src/components/pretty-address.tsx
@@ -10,18 +10,27 @@ interface Props {
   forceShort?: boolean;
   prefixLength?: number;
   suffixLength?: number;
+  disableTooltip?: boolean;
 }
 
-export default function PrettyAddress({ address, copyable, className, forceShort, prefixLength, suffixLength }: Props) {
+export default function PrettyAddress({
+  address,
+  copyable,
+  className,
+  forceShort,
+  prefixLength,
+  suffixLength,
+  disableTooltip,
+}: Props) {
   return (
     <div className="gap-small inline-flex items-center">
       {forceShort ? (
-        <Tooltip enabledSafePolygon content={address}>
+        <Tooltip enabledSafePolygon content={address} enabled={!disableTooltip}>
           <span className={className}>{toShortAdrress(address, prefixLength, suffixLength)}</span>
         </Tooltip>
       ) : (
         <>
-          <Tooltip enabledSafePolygon content={address} className={`lg:hidden ${className}`}>
+          <Tooltip enabledSafePolygon content={address} className={`lg:hidden ${className}`} enabled={!disableTooltip}>
             <span>{toShortAdrress(address, prefixLength, suffixLength)}</span>
           </Tooltip>
           <span className={`hidden lg:inline ${className}`}>{address}</span>

--- a/apps/web/src/components/user.tsx
+++ b/apps/web/src/components/user.tsx
@@ -44,6 +44,7 @@ export default function User({ placement, prefixLength = 10, suffixLength = 8 }:
           suffixLength={suffixLength}
           address={address}
           copyable
+          disableTooltip
           className="text-sm font-extrabold text-white"
         />
       </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new prop `disableTooltip` to the `PrettyAddress` component in `pretty-address.tsx` to conditionally disable tooltips.

### Detailed summary
- Added `disableTooltip` prop to `PrettyAddress` component
- Conditionally disabled tooltips based on the value of `disableTooltip`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->