### PR TITLE
Fix explorer of Zircuit Testnet

### DIFF
--- a/apps/web/src/config/chains/zircuit.ts
+++ b/apps/web/src/config/chains/zircuit.ts
@@ -67,7 +67,7 @@ export const zircuitChain: ChainConfig = {
   blockExplorers: {
     default: {
       name: "Zircuit Explorer",
-      url: "https://explorer.zircuit.com",
+      url: "https://explorer.testnet.zircuit.com",
     },
   },
   contracts: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the URL for the Zircuit Explorer from the mainnet to the testnet.

### Detailed summary
- Updated the URL for the Zircuit Explorer from "https://explorer.zircuit.com" to "https://explorer.testnet.zircuit.com" in `apps/web/src/config/chains/zircuit.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->