### PR TITLE
Update order of tokens

### DIFF
--- a/apps/web/src/utils/transfer.ts
+++ b/apps/web/src/utils/transfer.ts
@@ -11,7 +11,7 @@ const allTokenOptions: Record<Exclude<TokenCategory, "others">, TokenOption> = {
   PINK: { logo: "pink.png", category: "PINK", symbol: "PINK" },
 };
 const sortedTokenCategories: Exclude<TokenCategory, "others">[] = isMainnet()
-  ? ["USDT", "USDC", "ETH", "RING", "CRAB", "PINK"]
+  ? ["USDC", "USDT", "ETH", "RING", "CRAB", "PINK"]
   : ["USDC", "USDT", "ETH", "RING", "CRAB"];
 const availableTokenCategories = new Set<TokenCategory>();
 const sourceChainOptions = new Map<TokenCategory, ChainConfig[]>();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on reordering token categories for transfers in the web app.

### Detailed summary
- Reordered token categories for transfers in `transfer.ts`
- Moved "USDT" after "USDC" for mainnet
- No changes for non-mainnet configurations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->