### PR TITLE
Support Zircuit mainnet

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@apollo/client": "^3.10.3",
     "@floating-ui/react": "^0.26.14",
-    "@helixbridge/helixconf": "1.1.10",
+    "@helixbridge/helixconf": "1.1.11",
     "@rainbow-me/rainbowkit": "^1.3.7",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",

--- a/apps/web/src/config/chains/index.ts
+++ b/apps/web/src/config/chains/index.ts
@@ -22,3 +22,4 @@ export * from "./base-sepolia";
 export * from "./avalanche";
 export * from "./taiko-hekla";
 export * from "./zircuit";
+export * from "./zircuit-sepolia";

--- a/apps/web/src/config/chains/zircuit-sepolia.ts
+++ b/apps/web/src/config/chains/zircuit-sepolia.ts
@@ -3,7 +3,7 @@ import { ChainConfig, ChainID, Network } from "../../types/chain";
 import { BridgeV2Type } from "../../types";
 import { Address } from "viem";
 
-const chain = HelixChain.zircuit;
+const chain = HelixChain.zircuitSepolia;
 const tokens = chain.tokens.map((token) => {
   const couples = chain.filterCouples({ symbolFrom: token.symbol });
   const category = couples.at(0)?.category ?? "Others";
@@ -48,33 +48,35 @@ if (chain.couples.length && !chain.tokens.some((t) => t.type === "native")) {
   });
 }
 
-export const zircuitChain: ChainConfig = {
+export const zircuitSepoliaChain: ChainConfig = {
   /**
    * Chain
    */
-  id: ChainID.ZIRCUIT,
-  network: "zircuit",
-  name: "Zircuit",
+  id: ChainID.ZIRCUIT_SEPOLIA,
+  network: "zircuit-sepolia",
+  name: "Zircuit Sepolia",
   nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
   rpcUrls: {
     default: {
-      http: ["https://zircuit1-mainnet.p2pify.com"],
+      http: ["https://zircuit1.p2pify.com"],
     },
     public: {
-      http: ["https://zircuit1-mainnet.p2pify.com"],
+      http: ["https://zircuit1.p2pify.com"],
     },
   },
   blockExplorers: {
     default: {
       name: "Zircuit Explorer",
-      url: "https://explorer.zircuit.com",
+      url: "https://explorer.testnet.zircuit.com",
     },
   },
   contracts: {
     multicall3: {
       address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 6040287,
     },
   },
+  testnet: true,
 
   /**
    * Custom

--- a/apps/web/src/types/chain.ts
+++ b/apps/web/src/types/chain.ts
@@ -32,7 +32,8 @@ export enum ChainID {
   MORPH = 2710,
   MOONBEAM = 1284,
   AVALANCHE = 43_114,
-  ZIRCUIT = 48899,
+  ZIRCUIT = 48900,
+  ZIRCUIT_SEPOLIA = 48899,
 }
 
 // According to graphql indexer
@@ -61,6 +62,7 @@ export type Network =
   | "moonbeam"
   | "avalanche"
   | "zircuit"
+  | "zircuit-sepolia"
   | "bsc";
 
 export interface ChainConfig extends Chain {

--- a/apps/web/src/utils/chain.ts
+++ b/apps/web/src/utils/chain.ts
@@ -19,6 +19,7 @@ import {
   sepoliaChain,
   taikoHeklaChain,
   zircuitChain,
+  zircuitSepoliaChain,
   zksyncChain,
   zksyncSepoliaChain,
 } from "../config/chains";
@@ -105,6 +106,9 @@ export function getChainConfig(chainIdOrNetwork?: ChainID | Network | null): Cha
     case ChainID.ZIRCUIT:
     case "zircuit":
       return zircuitChain;
+    case ChainID.ZIRCUIT_SEPOLIA:
+    case "zircuit-sepolia":
+      return zircuitSepoliaChain;
     default:
       return;
   }
@@ -137,6 +141,7 @@ export function getChainConfigs(askAll?: boolean) {
     baseSepoliaChain,
     avalancheChain,
     zircuitChain,
+    zircuitSepoliaChain,
   ].sort((a, b) => a.name.localeCompare(b.name));
 
   if (askAll) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^0.26.14
         version: 0.26.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@helixbridge/helixconf":
-        specifier: 1.1.10
-        version: 1.1.10
+        specifier: 1.1.11
+        version: 1.1.11
       "@rainbow-me/rainbowkit":
         specifier: ^1.3.7
         version: 1.3.7(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@1.21.4(typescript@5.5.4))(wagmi@1.4.13(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(viem@1.21.4(typescript@5.5.4)))
@@ -1003,9 +1003,9 @@ packages:
     resolution:
       { integrity: sha512-KJ1rA4/43Jl7oQ6LBeTPeP9rfm1kaY5SNF8zFnECTVSY+GBMY0SuJddumw0a0fdwHxV1FhSnEE82ObVpbv4QqQ== }
 
-  "@helixbridge/helixconf@1.1.10":
+  "@helixbridge/helixconf@1.1.11":
     resolution:
-      { integrity: sha512-wDRCsWKo0dmiMPCufD9qI+z/7fwZAEDYDNVmn6ttnBokNK0bVH5xSBKOVuhc5colHiiYuUlllWXYt1Yabi6cnQ== }
+      { integrity: sha512-qNtIzc0CUMhpOIO6DDpJRMTLOlKD3WHcVSkAJOERAQkv0f1RvJHF7TwpJEDcSSUCXHOiAX0DiFb5skGh16p7xA== }
 
   "@humanwhocodes/config-array@0.11.14":
     resolution:
@@ -6222,7 +6222,7 @@ snapshots:
 
   "@helixbridge/helixconf@1.1.1": {}
 
-  "@helixbridge/helixconf@1.1.10": {}
+  "@helixbridge/helixconf@1.1.11": {}
 
   "@humanwhocodes/config-array@0.11.14":
     dependencies:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add support for a new chain called `Zircuit Sepolia` and update dependencies like `@helixbridge/helixconf` to version `1.1.11`.

### Detailed summary
- Added support for `Zircuit Sepolia` chain
- Updated `@helixbridge/helixconf` to version `1.1.11`
- Updated chain configurations and utilities for the new chain
- Updated package versions in `package.json` to include dependency changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->