### PR TITLE
Update some graphql fetchPolicy

### DIFF
--- a/apps/web/src/components/record-detail.tsx
+++ b/apps/web/src/components/record-detail.tsx
@@ -32,6 +32,7 @@ export default function RecordDetail(props: Props) {
   } = useQuery<HistoryRecordResData, HistoryRecordReqParams>(GQL_HISTORY_RECORD_BY_ID, {
     variables: { id: props.id },
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: "cache-and-network",
   });
   const navigate = useNavigate();
 

--- a/apps/web/src/hooks/use-history-details.ts
+++ b/apps/web/src/hooks/use-history-details.ts
@@ -6,7 +6,7 @@ import { useQuery } from "@apollo/client";
 export function useHistoryDetails(txHash: Hash | null | undefined) {
   const { loading, data } = useQuery<HistoryDetailsResData, HistoryDetailsReqParams>(GQL_GET_HISTORY_DETAILS, {
     variables: { txHash: txHash ?? "" },
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-and-network",
     pollInterval: txHash ? 4500 : 0,
     skip: !txHash,
   });

--- a/apps/web/src/hooks/use-history.ts
+++ b/apps/web/src/hooks/use-history.ts
@@ -12,7 +12,7 @@ export function useHistory(page: number, enabled?: boolean) {
     refetch,
   } = useQuery<HistoryResData, HistoryReqParams>(GQL_GET_HISTORY, {
     variables: { bridges: ["lnv2-opposite", "lnv2-default", "lnv3"], sender: account.address, row: 10, page },
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-and-network",
     pollInterval: enabled ? 3000 : 0,
     skip: !enabled,
   });

--- a/apps/web/src/hooks/use-max-transfer.ts
+++ b/apps/web/src/hooks/use-max-transfer.ts
@@ -11,6 +11,7 @@ export function useMaxTransfer(sourceChain: ChainConfig, targetChain: ChainConfi
       token: token.address,
       balance: balance.toString(),
     },
+    fetchPolicy: "no-cache",
   });
   const [maxTransfer, setMaxTransfer] = useState(BigInt(Number.MAX_SAFE_INTEGER) ** BigInt(token.decimals));
 

--- a/apps/web/src/hooks/use-relayers-data.ts
+++ b/apps/web/src/hooks/use-relayers-data.ts
@@ -25,7 +25,7 @@ export function useRelayersData(
       row,
     },
     notifyOnNetworkStatusChange: true,
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-and-network",
   });
 
   const [data, setData] = useState(_data?.queryLnBridgeRelayInfos.records ?? []);

--- a/apps/web/src/hooks/use-sorted-relay-data.ts
+++ b/apps/web/src/hooks/use-sorted-relay-data.ts
@@ -16,6 +16,7 @@ export function useSortedRelayData(amount: bigint, token: Token, sourceChain: Ch
       fromChain: sourceChain.network,
       toChain: targetChain.network,
     },
+    fetchPolicy: "network-only",
   });
   const [data, setData] = useState(_data);
 

--- a/apps/web/src/hooks/use-txs.ts
+++ b/apps/web/src/hooks/use-txs.ts
@@ -12,7 +12,7 @@ export function useTxs(sender: string, page: number, row = 10) {
   } = useQuery<TxsResData, TxsReqParams>(GQL_GET_TXS, {
     variables: { sender, bridges: ["lnv3", "lnv2-default", "lnv2-opposite"], page, row },
     notifyOnNetworkStatusChange: true,
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-and-network",
   });
 
   const [data, setData] = useState(_data?.historyRecords.records ?? []);


### PR DESCRIPTION
Close #790 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update fetch policies in various hooks and components to optimize data fetching strategies.

### Detailed summary
- Updated fetch policy to "network-only" in `use-sorted-relay-data.ts`
- Updated fetch policy to "cache-and-network" in `record-detail.tsx`
- Updated fetch policy to "no-cache" in `use-max-transfer.ts`
- Updated fetch policy to "cache-and-network" in `use-relayers-data.ts`
- Updated fetch policy to "cache-and-network" in `use-txs.ts`
- Updated fetch policy to "cache-and-network" in `use-history-details.ts`
- Updated fetch policy to "cache-and-network" in `use-history.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->