### PR TITLE
Fix explorer of Gnosis

### DIFF
--- a/apps/web/src/config/chains/gnosis.ts
+++ b/apps/web/src/config/chains/gnosis.ts
@@ -54,6 +54,12 @@ export const gnosisChain: ChainConfig = {
   ...gnosis,
   network: "gnosis",
   name: "Gnosis Chain",
+  blockExplorers: {
+    default: {
+      name: "Gnosisscan",
+      url: "https://gnosisscan.io",
+    },
+  },
 
   /**
    * Custom


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a new block explorer for the Gnosis chain.

### Detailed summary
- Added a new block explorer named "Gnosisscan" for the Gnosis chain
- Block explorer URL set to "https://gnosisscan.io"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->