### PR TITLE
Hide PWA reload

### DIFF
--- a/apps/web/src/components/pwa-badge.tsx
+++ b/apps/web/src/components/pwa-badge.tsx
@@ -1,6 +1,9 @@
 import { useRegisterSW } from "virtual:pwa-register/react";
 import Button from "../ui/button";
 
+const isPWA = window.matchMedia("(display-mode: standalone)").matches;
+const enableReload = false;
+
 export default function PWABadge() {
   // Periodic sync is disabled, change the value to enable it, the period is in milliseconds
   // You can remove onRegisteredSW callback and registerPeriodicSync function
@@ -29,7 +32,7 @@ export default function PWABadge() {
 
   return (
     <div role="alert" aria-labelledby="toast-message">
-      {needRefresh && (
+      {needRefresh && isPWA && enableReload && (
         <div className="bg-background fixed bottom-0 right-0 z-10 m-4 flex flex-col gap-y-3 rounded-xl border border-white/20 p-3 text-left">
           <span id="toast-message" className="text-sm font-bold text-white">
             New content available, click on reload button to update.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a PWA badge component in `pwa-badge.tsx` to prompt users to reload for new content in standalone mode.

### Detailed summary
- Added `isPWA` constant to check if in PWA mode
- Introduced `enableReload` constant for reload button toggle
- Updated rendering condition to show badge only in PWA mode and when reload is enabled

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->