### PR TITLE
Update astar-zkevm rpc

### DIFF
--- a/apps/web/src/config/chains/astar-zkevm.ts
+++ b/apps/web/src/config/chains/astar-zkevm.ts
@@ -62,11 +62,11 @@ export const astarZkEvmChain: ChainConfig = {
   },
   rpcUrls: {
     default: {
-      http: ["https://rpc.astar-zkevm.gelato.digital"],
+      http: ["https://rpc.startale.com/astar-zkevm"],
       webSocket: [],
     },
     public: {
-      http: ["https://rpc.astar-zkevm.gelato.digital"],
+      http: ["https://rpc.startale.com/astar-zkevm"],
       webSocket: [],
     },
   },


### PR DESCRIPTION
Close #825 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `rpcUrls` in the `astar-zkevm.ts` configuration file to change the HTTP endpoint for both default and public RPC URLs from `https://rpc.astar-zkevm.gelato.digital` to `https://rpc.startale.com/astar-zkevm`.

### Detailed summary
- Updated `rpcUrls.default.http` from `https://rpc.astar-zkevm.gelato.digital` to `https://rpc.startale.com/astar-zkevm`
- Updated `rpcUrls.public.http` from `https://rpc.astar-zkevm.gelato.digital` to `https://rpc.startale.com/astar-zkevm`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->