### PR TITLE
Refactor explorer tx query

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+_generated_

--- a/apps/web/codegen.ts
+++ b/apps/web/codegen.ts
@@ -1,0 +1,15 @@
+import type { CodegenConfig } from "@graphql-codegen/cli";
+
+const config: CodegenConfig = {
+  overwrite: true,
+  schema: "https://apollo.helixbridge.app/graphql",
+  documents: "src/hooks/**/*.ts",
+  generates: {
+    "src/_generated_/gql/": {
+      preset: "client",
+      plugins: [],
+    },
+  },
+};
+
+export default config;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "vitest --run --silent",
     "clean": "rm -rf node_modules .turbo dist",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "codegen:graphql": "graphql-codegen --config codegen.ts"
   },
   "license": "MIT",
   "dependencies": {
@@ -39,6 +40,9 @@
     "wagmi": "^1.4.13"
   },
   "devDependencies": {
+    "@graphql-codegen/cli": "5.0.3",
+    "@graphql-codegen/client-preset": "4.4.0",
+    "@graphql-typed-document-node/core": "^3.2.0",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@types/react-transition-group": "^4.4.10",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "build:testnet": "tsc && vite build --mode testnet && node scripts/generate-sitemap.js",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "vitest --run --silent",
-    "clean": "rm -rf node_modules .turbo dist",
+    "clean": "rm -rf node_modules .turbo dist src/_generated_",
     "preview": "vite preview",
     "codegen:graphql": "graphql-codegen --config codegen.ts"
   },

--- a/apps/web/src/components/record-detail.tsx
+++ b/apps/web/src/components/record-detail.tsx
@@ -1,10 +1,8 @@
 import { BaseBridge } from "../bridges";
-import { GQL_HISTORY_RECORD_BY_ID } from "../config";
-import { HistoryRecordReqParams, HistoryRecordResData } from "../types";
+import { BridgeCategory, Network } from "../types";
 import ComponentLoading from "../ui/component-loading";
 import CountdownRefresh from "../ui/countdown-refresh";
 import { bridgeFactory, getChainConfig } from "../utils";
-import { useQuery } from "@apollo/client";
 import { PropsWithChildren, useMemo } from "react";
 import TransferRoute from "./transfer-route";
 import TransactionStatus from "./transaction-status";
@@ -18,6 +16,8 @@ import TransactionFee from "./transaction-fee";
 import { RecordItemTitle } from "../ui/record-item-title";
 import { useNavigate } from "react-router-dom";
 import Back from "./icons/back";
+import { useExplorerTx } from "../hooks/use-explorer-tx";
+import { Address } from "viem";
 
 interface Props {
   id: string;
@@ -25,21 +25,13 @@ interface Props {
 }
 
 export default function RecordDetail(props: Props) {
-  const {
-    loading,
-    data: record,
-    refetch,
-  } = useQuery<HistoryRecordResData, HistoryRecordReqParams>(GQL_HISTORY_RECORD_BY_ID, {
-    variables: { id: props.id },
-    notifyOnNetworkStatusChange: true,
-    fetchPolicy: "cache-and-network",
-  });
+  const { data: record, loading, refetch } = useExplorerTx(props.id);
   const navigate = useNavigate();
 
   const bridgeInstance = useMemo<BaseBridge | undefined>(() => {
-    const category = record?.historyRecordById?.bridge;
-    const sourceChain = getChainConfig(record?.historyRecordById?.fromChain);
-    const targetChain = getChainConfig(record?.historyRecordById?.toChain);
+    const category = record?.historyRecordById?.bridge as BridgeCategory | undefined;
+    const sourceChain = getChainConfig(record?.historyRecordById?.fromChain as Network | undefined);
+    const targetChain = getChainConfig(record?.historyRecordById?.toChain as Network | undefined);
     const sourceToken = sourceChain?.tokens.find(
       (t) => t.symbol.toUpperCase() === record?.historyRecordById?.sendToken.toUpperCase(),
     );
@@ -86,7 +78,7 @@ export default function RecordDetail(props: Props) {
             tips="Unique character string (TxID) assigned to every verified transaction on the Source Chain."
           >
             <TransactionHash
-              chain={record?.historyRecordById?.fromChain}
+              chain={record?.historyRecordById?.fromChain as Network | undefined}
               txHash={record?.historyRecordById?.requestTxHash}
             />
           </Item>
@@ -95,7 +87,7 @@ export default function RecordDetail(props: Props) {
             tips="Unique character string (TxID) assigned to every verified transaction on the Target Chain."
           >
             <TransactionHash
-              chain={record?.historyRecordById?.toChain}
+              chain={record?.historyRecordById?.toChain as Network | undefined}
               txHash={record?.historyRecordById?.responseTxHash}
             />
           </Item>
@@ -111,7 +103,7 @@ export default function RecordDetail(props: Props) {
           <Item label="Sender" tips="Address (external or contract) sending the transaction.">
             {record?.historyRecordById?.sender ? (
               <PrettyAddress
-                address={record.historyRecordById.sender}
+                address={record.historyRecordById.sender as Address}
                 className="text-primary text-sm font-medium"
                 copyable
               />
@@ -120,7 +112,7 @@ export default function RecordDetail(props: Props) {
           <Item label="Receiver" tips="Address (external or contract) receiving the transaction.">
             {record?.historyRecordById?.recipient ? (
               <PrettyAddress
-                address={record.historyRecordById.recipient}
+                address={record.historyRecordById.recipient as Address}
                 className="text-primary text-sm font-medium"
                 copyable
               />
@@ -152,7 +144,7 @@ export default function RecordDetail(props: Props) {
           <Item label="Solver">
             {record?.historyRecordById?.relayer ? (
               <PrettyAddress
-                address={record.historyRecordById.relayer}
+                address={record.historyRecordById.relayer as Address}
                 className="text-primary text-sm font-medium"
                 copyable
               />

--- a/apps/web/src/components/token-to-receive.tsx
+++ b/apps/web/src/components/token-to-receive.tsx
@@ -1,15 +1,16 @@
-import { HistoryRecord } from "../types/graphql";
+import { ExplorerTxByIdQuery } from "../_generated_/gql/graphql";
 import PrettyAddress from "./pretty-address";
 import { getTokenLogoSrc } from "../utils/misc";
 import { getChainConfig } from "../utils/chain";
 import Button from "../ui/button";
+import { Network } from "../types";
 
 interface Props {
-  record?: HistoryRecord | null;
+  record: ExplorerTxByIdQuery["historyRecordById"];
 }
 
 export default function TokenToReceive({ record }: Props) {
-  const token = getChainConfig(record?.toChain)?.tokens.find(
+  const token = getChainConfig(record?.toChain as Network | undefined)?.tokens.find(
     ({ symbol, address }) =>
       symbol === record?.recvToken ||
       (record?.recvTokenAddress && address.toLowerCase() === record.recvTokenAddress?.toLowerCase()),

--- a/apps/web/src/components/token-transfer.tsx
+++ b/apps/web/src/components/token-transfer.tsx
@@ -1,4 +1,3 @@
-import { HistoryRecord } from "../types/graphql";
 import Tooltip from "../ui/tooltip";
 import PrettyAddress from "./pretty-address";
 import { BaseBridge } from "../bridges/base";
@@ -8,9 +7,10 @@ import { getChainConfig } from "../utils/chain";
 import { getChainLogoSrc, getTokenLogoSrc } from "../utils/misc";
 import { formatBalance } from "../utils/balance";
 import { Address } from "viem";
+import { ExplorerTxByIdQuery } from "../_generated_/gql/graphql";
 
 interface Props {
-  record?: HistoryRecord | null;
+  record: ExplorerTxByIdQuery["historyRecordById"];
   bridge?: BaseBridge | null;
 }
 
@@ -20,16 +20,16 @@ export default function TokenTransfer({ record, bridge }: Props) {
   return record && contract ? (
     <div className="flex flex-col items-start justify-between">
       <Item
-        chain={record.fromChain}
-        from={record.sender}
+        chain={record.fromChain as Network}
+        from={record.sender as Address}
         to={contract.sourceAddress}
         symbol={record.sendToken}
         amount={BigInt(record.sendAmount || 0)}
       />
       <Item
-        chain={record.toChain}
+        chain={record.toChain as Network}
         from={contract.targetAddress}
-        to={record.recipient}
+        to={record.recipient as Address}
         symbol={record.recvToken}
         amount={BigInt(record.recvAmount || 0)}
       />

--- a/apps/web/src/components/transaction-fee.tsx
+++ b/apps/web/src/components/transaction-fee.tsx
@@ -1,13 +1,14 @@
-import { HistoryRecord } from "../types/graphql";
+import { ExplorerTxByIdQuery } from "../_generated_/gql/graphql";
+import { Network } from "../types";
 import { formatBalance } from "../utils/balance";
 import { getChainConfig } from "../utils/chain";
 
 interface Props {
-  record?: HistoryRecord | null;
+  record: ExplorerTxByIdQuery["historyRecordById"];
 }
 
 export default function TransactionFee({ record }: Props) {
-  const token = getChainConfig(record?.fromChain)?.tokens.find(
+  const token = getChainConfig(record?.fromChain as Network | undefined)?.tokens.find(
     ({ symbol }) => symbol.toUpperCase() === record?.feeToken.toUpperCase(),
   );
 

--- a/apps/web/src/components/transaction-status.tsx
+++ b/apps/web/src/components/transaction-status.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from "react";
 import { bridgeFactory } from "../utils/bridge";
 import { interval } from "rxjs";
 import { formatCountdown } from "../utils/time";
-import { HistoryRecord, RecordResult } from "../types";
+import { BridgeCategory, RecordResult } from "../types";
 import { RecordResultTag } from "../ui/record-result-tag";
+import { ExplorerTxByIdQuery } from "../_generated_/gql/graphql";
 
 interface Props {
-  record?: HistoryRecord | null;
+  record: ExplorerTxByIdQuery["historyRecordById"];
 }
 
 export default function TransactionStatus({ record }: Props) {
@@ -21,7 +22,8 @@ export default function TransactionStatus({ record }: Props) {
   useEffect(() => {
     if (record?.bridge) {
       const startTime = record ? record.startTime * 1000 : Date.now();
-      const minTime = ((bridgeFactory({ category: record.bridge })?.getEstimateTime().min || 0) + 10) * 60 * 1000;
+      const minTime =
+        ((bridgeFactory({ category: record.bridge as BridgeCategory })?.getEstimateTime().min || 0) + 10) * 60 * 1000;
       setCountdown(minTime);
       setIsTimeout(Date.now() - startTime > minTime);
     } else {

--- a/apps/web/src/components/transaction-timestamp.tsx
+++ b/apps/web/src/components/transaction-timestamp.tsx
@@ -1,9 +1,9 @@
-import { HistoryRecord } from "../types/graphql";
+import { ExplorerTxByIdQuery } from "../_generated_/gql/graphql";
 import { formatTime, toTimeAgo } from "../utils/time";
 import { formatDistanceStrict } from "date-fns";
 
 interface Props {
-  record?: HistoryRecord | null;
+  record: ExplorerTxByIdQuery["historyRecordById"];
 }
 
 export default function TransactionTimestamp({ record }: Props) {

--- a/apps/web/src/components/transaction-value.tsx
+++ b/apps/web/src/components/transaction-value.tsx
@@ -1,13 +1,14 @@
-import { HistoryRecord } from "../types/graphql";
+import { ExplorerTxByIdQuery } from "../_generated_/gql/graphql";
+import { Network } from "../types";
 import { formatBalance } from "../utils/balance";
 import { getChainConfig } from "../utils/chain";
 
 interface Props {
-  record?: HistoryRecord | null;
+  record: ExplorerTxByIdQuery["historyRecordById"];
 }
 
 export default function TransactionValue({ record }: Props) {
-  const token = getChainConfig(record?.fromChain)?.tokens.find(
+  const token = getChainConfig(record?.fromChain as Network | undefined)?.tokens.find(
     ({ symbol }) => symbol.toUpperCase() === record?.sendToken.toUpperCase(),
   );
 

--- a/apps/web/src/components/transfer-route.tsx
+++ b/apps/web/src/components/transfer-route.tsx
@@ -2,17 +2,19 @@ import Tooltip from "../ui/tooltip";
 import { getChainConfig } from "../utils/chain";
 import { getChainLogoSrc } from "../utils/misc";
 import BridgeLogo from "./bridge-identicon";
-import { HistoryRecord } from "../types/graphql";
 import { bridgeFactory } from "../utils/bridge";
+import { ExplorerTxByIdQuery } from "../_generated_/gql/graphql";
+import { BridgeCategory } from "../types";
+import { Network } from "../types";
 
 interface Props {
-  record?: HistoryRecord | null;
+  record: ExplorerTxByIdQuery["historyRecordById"];
 }
 
 export default function TransferRoute({ record }: Props) {
-  const sourceChain = getChainConfig(record?.fromChain);
-  const targetChain = getChainConfig(record?.toChain);
-  const bridge = record ? bridgeFactory({ category: record.bridge }) : undefined;
+  const sourceChain = getChainConfig(record?.fromChain as Network | undefined);
+  const targetChain = getChainConfig(record?.toChain as Network | undefined);
+  const bridge = record ? bridgeFactory({ category: record.bridge as BridgeCategory }) : undefined;
 
   return (
     <div className="gap-large flex items-center">

--- a/apps/web/src/config/gql.ts
+++ b/apps/web/src/config/gql.ts
@@ -1,35 +1,5 @@
 import { gql } from "@apollo/client";
 
-export const GQL_HISTORY_RECORD_BY_ID = gql`
-  query historyRecordById($id: String!) {
-    historyRecordById(id: $id) {
-      sendAmount
-      recvAmount
-      bridge
-      endTime
-      fee
-      feeToken
-      fromChain
-      id
-      nonce
-      messageNonce
-      recipient
-      requestTxHash
-      responseTxHash
-      reason
-      result
-      sender
-      startTime
-      toChain
-      sendToken
-      recvToken
-      sendTokenAddress
-      recvTokenAddress
-      relayer
-    }
-  }
-`;
-
 export const GQL_SORTED_LNBRIDGE_RELAY_INFOS = gql`
   query sortedLnBridgeRelayInfos(
     $amount: String

--- a/apps/web/src/hooks/use-explorer-tx.ts
+++ b/apps/web/src/hooks/use-explorer-tx.ts
@@ -1,0 +1,42 @@
+import { useQuery } from "@apollo/client";
+import { graphql } from "../_generated_/gql";
+
+const document = graphql(`
+  query ExplorerTxById($id: String!) {
+    historyRecordById(id: $id) {
+      sendAmount
+      recvAmount
+      bridge
+      endTime
+      fee
+      feeToken
+      fromChain
+      id
+      nonce
+      messageNonce
+      recipient
+      requestTxHash
+      responseTxHash
+      reason
+      result
+      sender
+      startTime
+      toChain
+      sendToken
+      recvToken
+      sendTokenAddress
+      recvTokenAddress
+      relayer
+    }
+  }
+`);
+
+export function useExplorerTx(id: string) {
+  const { data, loading, refetch } = useQuery(document, {
+    variables: { id },
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: "cache-and-network",
+  });
+
+  return { data, loading, refetch };
+}

--- a/apps/web/src/types/graphql.ts
+++ b/apps/web/src/types/graphql.ts
@@ -83,14 +83,6 @@ export interface SupportChains {
  * Custom
  */
 
-export interface HistoryRecordReqParams {
-  id: string;
-}
-
-export interface HistoryRecordResData {
-  historyRecordById: HistoryRecord | null;
-}
-
 export interface SortedLnBridgeRelayInfosReqParams {
   amount: string;
   decimals?: number;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "version-packages": "changeset version",
     "release": "turbo build --filter=./packages/* && changeset publish",
     "prepare": "husky",
-    "postinstall": "pnpm run codegen:graphql --filter @helixbridge/web"
+    "postinstall": "pnpm --filter @helixbridge/web run codegen:graphql"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo build --filter=./packages/* && changeset publish",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "pnpm run codegen:graphql --filter @helixbridge/web"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
     dependencies:
       "@apollo/client":
         specifier: ^3.10.3
-        version: 3.11.1(@types/react@18.3.3)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.11.1(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@floating-ui/react":
         specifier: ^0.26.14
         version: 0.26.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -89,6 +89,15 @@ importers:
         specifier: ^1.4.13
         version: 1.4.13(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4))(react@18.3.1)(typescript@5.5.4)(viem@1.21.4(typescript@5.5.4))
     devDependencies:
+      "@graphql-codegen/cli":
+        specifier: 5.0.3
+        version: 5.0.3(@parcel/watcher@2.4.1)(@types/node@20.14.12)(enquirer@2.4.1)(graphql@16.9.0)(typescript@5.5.4)
+      "@graphql-codegen/client-preset":
+        specifier: 4.4.0
+        version: 4.4.0(graphql@16.9.0)
+      "@graphql-typed-document-node/core":
+        specifier: ^3.2.0
+        version: 3.2.0(graphql@16.9.0)
       "@types/react":
         specifier: ^18.2.66
         version: 18.3.3
@@ -196,7 +205,7 @@ importers:
         version: 29.7.0(@types/node@20.14.12)
       tsup:
         specifier: ^8.2.3
-        version: 8.2.3(@swc/core@1.7.22)(jiti@1.21.6)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5)
+        version: 8.2.3(@swc/core@1.7.22)(jiti@2.3.3)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5)
       typescript:
         specifier: ^5.2.2
         version: 5.5.4
@@ -266,7 +275,7 @@ importers:
         version: 8.57.0
       tsup:
         specifier: ^8.2.3
-        version: 8.2.3(@swc/core@1.7.22)(jiti@1.21.6)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5)
+        version: 8.2.3(@swc/core@1.7.22)(jiti@2.3.3)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5)
       typescript:
         specifier: ^5.2.2
         version: 5.5.4
@@ -312,7 +321,7 @@ importers:
         version: 29.7.0(@types/node@20.14.12)
       tsup:
         specifier: ^8.2.3
-        version: 8.2.3(@swc/core@1.7.22)(jiti@1.21.6)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5)
+        version: 8.2.3(@swc/core@1.7.22)(jiti@2.3.3)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5)
       typescript:
         specifier: ^5.2.2
         version: 5.5.4
@@ -383,6 +392,18 @@ packages:
         optional: true
       subscriptions-transport-ws:
         optional: true
+
+  "@ardatan/relay-compiler@12.0.0":
+    resolution:
+      { integrity: sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q== }
+    hasBin: true
+    peerDependencies:
+      graphql: "*"
+
+  "@ardatan/sync-fetch@0.0.1":
+    resolution:
+      { integrity: sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA== }
+    engines: { node: ">=14" }
 
   "@babel/code-frame@7.24.7":
     resolution:
@@ -639,6 +660,14 @@ packages:
       { integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA== }
     engines: { node: ">=6.9.0" }
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-object-rest-spread@7.20.7":
+    resolution:
+      { integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg== }
+    engines: { node: ">=6.9.0" }
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       "@babel/core": ^7.0.0-0
 
@@ -1776,6 +1805,252 @@ packages:
     resolution:
       { integrity: sha512-sTcG+QZ6fdEUObICavU+aB3Mp8HY4n14wYHdxK4fXjPmv3PXZZeY5RaguJmGyeH/CJQhX3fqKUtS4qc1LoHwhQ== }
 
+  "@graphql-codegen/add@5.0.3":
+    resolution:
+      { integrity: sha512-SxXPmramkth8XtBlAHu4H4jYcYXM/o3p01+psU+0NADQowA8jtYkK6MW5rV6T+CxkEaNZItfSmZRPgIuypcqnA== }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/cli@5.0.3":
+    resolution:
+      { integrity: sha512-ULpF6Sbu2d7vNEOgBtE9avQp2oMgcPY/QBYcCqk0Xru5fz+ISjcovQX29V7CS7y5wWBRzNLoXwJQGeEyWbl05g== }
+    engines: { node: ">=16" }
+    hasBin: true
+    peerDependencies:
+      "@parcel/watcher": ^2.1.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      "@parcel/watcher":
+        optional: true
+
+  "@graphql-codegen/client-preset@4.4.0":
+    resolution:
+      { integrity: sha512-Q0NHFK7KXLhEaRC/k82ge0dHDfeHJEvvDeV0vV3+oSurHNa/lpxQtbK2BqknZe+JDfZ1YOOvYT93XsAkYD+SQg== }
+    engines: { node: ">=16" }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/core@4.0.2":
+    resolution:
+      { integrity: sha512-IZbpkhwVqgizcjNiaVzNAzm/xbWT6YnGgeOLwVjm4KbJn3V2jchVtuzHH09G5/WkkLSk2wgbXNdwjM41JxO6Eg== }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/gql-tag-operations@4.0.10":
+    resolution:
+      { integrity: sha512-WsBEVL3XQdBboFJJL5WxrUjkuo3B7Sa51R9NbT7PKBe0HCNstoouGZIvQJRUubttFCqTTyoFtNsoRSKB+rsRug== }
+    engines: { node: ">=16" }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/plugin-helpers@5.0.4":
+    resolution:
+      { integrity: sha512-MOIuHFNWUnFnqVmiXtrI+4UziMTYrcquljaI5f/T/Bc7oO7sXcfkAvgkNWEEi9xWreYwvuer3VHCuPI/lAFWbw== }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/schema-ast@4.1.0":
+    resolution:
+      { integrity: sha512-kZVn0z+th9SvqxfKYgztA6PM7mhnSZaj4fiuBWvMTqA+QqQ9BBed6Pz41KuD/jr0gJtnlr2A4++/0VlpVbCTmQ== }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/typed-document-node@5.0.10":
+    resolution:
+      { integrity: sha512-YPDUNs6x0muoVWlbY2yEs0lGxFHMTszlGDh6klT/5rqiTDTZg3zz8Wd1ZTihkcH8+V6T0AT9qDWwcx9fcS2tvQ== }
+    engines: { node: ">=16" }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/typescript-operations@4.3.0":
+    resolution:
+      { integrity: sha512-ZORwMy8OgsiYd9EZUhTMd4/g5LvTFpx6Fh6dNN0cxFkqSc6KhjX0vhzWsyK8N9+ILaHSutT8UTrLMdJi35HzDQ== }
+    engines: { node: ">=16" }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/typescript@4.1.0":
+    resolution:
+      { integrity: sha512-/fS53Nh6U6c58GTOxqfyKTLQfQv36P8II/vPw/fg0cdcWbALhRPls69P8vXUWjrElmLKzCrdusBWPp/r+AKUBQ== }
+    engines: { node: ">=16" }
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-codegen/visitor-plugin-common@5.4.0":
+    resolution:
+      { integrity: sha512-tL7hOrO+4MiNfDiHewhRQCiH9GTAh0M9Y/BZxYGGEdnrfGgqK5pCxtjq7EY/L19VGIyU7hhzYTQ0r1HzEbB4Jw== }
+    engines: { node: ">=16" }
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  "@graphql-tools/apollo-engine-loader@8.0.1":
+    resolution:
+      { integrity: sha512-NaPeVjtrfbPXcl+MLQCJLWtqe2/E4bbAqcauEOQ+3sizw1Fc2CNmhHRF8a6W4D0ekvTRRXAMptXYgA2uConbrA== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/batch-execute@9.0.4":
+    resolution:
+      { integrity: sha512-kkebDLXgDrep5Y0gK1RN3DMUlLqNhg60OAz0lTCqrYeja6DshxLtLkj+zV4mVbBA4mQOEoBmw6g1LZs3dA84/w== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/code-file-loader@8.1.3":
+    resolution:
+      { integrity: sha512-Qoo8VyU0ux7k20DkzL5wFm7Y6iqlG1GQ0xA4T3EQbm4B/qbENsMc38l76QnXYIVmIlKAnD9EAvzxPEQ8iv+ZPA== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/delegate@10.0.21":
+    resolution:
+      { integrity: sha512-UytyYVvDfLQbCYG1aQo8Vc67c1WhEjzW9ytYKEEqMJSdlwfMCujHmCz7EyH5DNjTAKapDHuQcN5VivKGap/Beg== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/documents@1.0.1":
+    resolution:
+      { integrity: sha512-aweoMH15wNJ8g7b2r4C4WRuJxZ0ca8HtNO54rkye/3duxTkW4fGBEutCx03jCIr5+a1l+4vFJNP859QnAVBVCA== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/executor-graphql-ws@1.3.0":
+    resolution:
+      { integrity: sha512-waghXHJjJiEEiWNYLbV7aRUbdvZOelSrtTgqpwco15k9iE4CMJyy2GQihLPEkIHcqSW0EHBlH1BbWDHI7noFPw== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/executor-http@1.1.6":
+    resolution:
+      { integrity: sha512-wGKjJzbi6em8cWI3sry6T7kAgoxMXYNM+KlbsWczPvIsHvv1cqXlrP1lwC6f7Ja1FfWdU1ZIEgOv93ext7IDyQ== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/executor-legacy-ws@1.1.0":
+    resolution:
+      { integrity: sha512-k+6ZyiaAd8SmwuzbEOfA/LVkuI1nqidhoMw+CJ7c41QGOjSMzc0VS0UZbJyeitI0n7a+uP/Meln1wjzJ2ReDtQ== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/executor@1.3.1":
+    resolution:
+      { integrity: sha512-tgJDdGf9SCAm64ofEMZdv925u6/J+eTmv36TGNLxgP2DpCJsZ6gnJ4A+0D28EazDXqJIvMiPd+3d+o3cCRCAnQ== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/git-loader@8.0.7":
+    resolution:
+      { integrity: sha512-+s23lxHR24+zLDk9/Hfl7/8Qcal8Q1yJ8armRp1fvcJyuc0RTZv97ZoZb0tArTfME74z+kJ92Mx4SfZMd7mHSQ== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/github-loader@8.0.1":
+    resolution:
+      { integrity: sha512-W4dFLQJ5GtKGltvh/u1apWRFKBQOsDzFxO9cJkOYZj1VzHCpRF43uLST4VbCfWve+AwBqOuKr7YgkHoxpRMkcg== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/graphql-file-loader@8.0.1":
+    resolution:
+      { integrity: sha512-7gswMqWBabTSmqbaNyWSmRRpStWlcCkBc73E6NZNlh4YNuiyKOwbvSkOUYFOqFMfEL+cFsXgAvr87Vz4XrYSbA== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/graphql-tag-pluck@8.3.2":
+    resolution:
+      { integrity: sha512-wJKkDjXRg2qJAVhAVE96zJGMli8Ity9mKUB7gTbvJwsAniaquRqLcTXUQ19X9qVT4ACzbbp+tAfk96b2U3tfog== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/import@7.0.1":
+    resolution:
+      { integrity: sha512-935uAjAS8UAeXThqHfYVr4HEAp6nHJ2sximZKO1RzUTq5WoALMAhhGARl0+ecm6X+cqNUwIChJbjtaa6P/ML0w== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/json-file-loader@8.0.1":
+    resolution:
+      { integrity: sha512-lAy2VqxDAHjVyqeJonCP6TUemrpYdDuKt25a10X6zY2Yn3iFYGnuIDQ64cv3ytyGY6KPyPB+Kp+ZfOkNDG3FQA== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/load@8.0.2":
+    resolution:
+      { integrity: sha512-S+E/cmyVmJ3CuCNfDuNF2EyovTwdWfQScXv/2gmvJOti2rGD8jTt9GYVzXaxhblLivQR9sBUCNZu/w7j7aXUCA== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/merge@9.0.7":
+    resolution:
+      { integrity: sha512-lbTrIuXIbUSmSumHkPRY1QX0Z8JEtmRhnIrkH7vkfeEmf0kNn/nCWvJwqokm5U7L+a+DA1wlRM4slIlbfXjJBA== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/optimize@2.0.0":
+    resolution:
+      { integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/prisma-loader@8.0.4":
+    resolution:
+      { integrity: sha512-hqKPlw8bOu/GRqtYr0+dINAI13HinTVYBDqhwGAPIFmLr5s+qKskzgCiwbsckdrb5LWVFmVZc+UXn80OGiyBzg== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/relay-operation-optimizer@7.0.1":
+    resolution:
+      { integrity: sha512-y0ZrQ/iyqWZlsS/xrJfSir3TbVYJTYmMOu4TaSz6F4FRDTQ3ie43BlKkhf04rC28pnUOS4BO9pDcAo1D30l5+A== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/schema@10.0.6":
+    resolution:
+      { integrity: sha512-EIJgPRGzpvDFEjVp+RF1zNNYIC36BYuIeZ514jFoJnI6IdxyVyIRDLx/ykgMdaa1pKQerpfdqDnsF4JnZoDHSQ== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/url-loader@8.0.2":
+    resolution:
+      { integrity: sha512-1dKp2K8UuFn7DFo1qX5c1cyazQv2h2ICwA9esHblEqCYrgf69Nk8N7SODmsfWg94OEaI74IqMoM12t7eIGwFzQ== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/utils@10.5.4":
+    resolution:
+      { integrity: sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  "@graphql-tools/wrap@10.0.5":
+    resolution:
+      { integrity: sha512-Cbr5aYjr3HkwdPvetZp1cpDWTGdD1Owgsb3z/ClzhmrboiK86EnQDxDvOJiQkDCPWE9lNBwj8Y4HfxroY0D9DQ== }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   "@graphql-typed-document-node/core@3.2.0":
     resolution:
       { integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ== }
@@ -1954,6 +2229,10 @@ packages:
   "@jridgewell/trace-mapping@0.3.25":
     resolution:
       { integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ== }
+
+  "@kamilkisiela/fast-url-parser@1.1.4":
+    resolution:
+      { integrity: sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew== }
 
   "@lit-labs/ssr-dom-shim@1.2.0":
     resolution:
@@ -2338,6 +2617,10 @@ packages:
     resolution:
       { integrity: sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw== }
     engines: { node: ">=14.0.0" }
+
+  "@repeaterjs/repeater@3.0.6":
+    resolution:
+      { integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA== }
 
   "@rollup/plugin-babel@5.3.1":
     resolution:
@@ -3523,6 +3806,10 @@ packages:
     resolution:
       { integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw== }
 
+  "@types/js-yaml@4.0.9":
+    resolution:
+      { integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg== }
+
   "@types/ms@0.7.34":
     resolution:
       { integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g== }
@@ -3570,6 +3857,10 @@ packages:
   "@types/trusted-types@2.0.7":
     resolution:
       { integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw== }
+
+  "@types/ws@8.5.12":
+    resolution:
+      { integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ== }
 
   "@types/yargs-parser@21.0.3":
     resolution:
@@ -3869,6 +4160,16 @@ packages:
     resolution:
       { integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA== }
 
+  "@whatwg-node/fetch@0.9.21":
+    resolution:
+      { integrity: sha512-Wt0jPb+04JjobK0pAAN7mEHxVHcGA9HoP3OyCsZtyAecNQeADXCZ1MihFwVwjsgaRYuGVmNlsCmLxlG6mor8Gw== }
+    engines: { node: ">=18.0.0" }
+
+  "@whatwg-node/node-fetch@0.5.26":
+    resolution:
+      { integrity: sha512-4jXDeZ4IH4bylZ6wu14VEx0aDXXhrN4TC279v9rPmn08g4EYekcYf8wdcOOnS9STjDkb6x77/6xBUTqxGgjr8g== }
+    engines: { node: ">=18.0.0" }
+
   "@wry/caches@1.0.1":
     resolution:
       { integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA== }
@@ -3963,6 +4264,16 @@ packages:
     resolution:
       { integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ== }
     engines: { node: ">= 6.0.0" }
+
+  agent-base@7.1.1:
+    resolution:
+      { integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA== }
+    engines: { node: ">= 14" }
+
+  aggregate-error@3.1.0:
+    resolution:
+      { integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA== }
+    engines: { node: ">=8" }
 
   ajv@6.12.6:
     resolution:
@@ -4093,6 +4404,11 @@ packages:
       { integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg== }
     engines: { node: ">=4" }
 
+  astral-regex@2.0.0:
+    resolution:
+      { integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ== }
+    engines: { node: ">=8" }
+
   async-limiter@1.0.1:
     resolution:
       { integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ== }
@@ -4114,6 +4430,11 @@ packages:
     resolution:
       { integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ== }
     engines: { node: ">=8.0.0" }
+
+  auto-bind@4.0.0:
+    resolution:
+      { integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ== }
+    engines: { node: ">=8" }
 
   autoprefixer@10.4.19:
     resolution:
@@ -4179,6 +4500,10 @@ packages:
     peerDependencies:
       "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
 
+  babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
+    resolution:
+      { integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ== }
+
   babel-plugin-transform-flow-enums@0.0.2:
     resolution:
       { integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ== }
@@ -4186,6 +4511,12 @@ packages:
   babel-preset-current-node-syntax@1.0.1:
     resolution:
       { integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ== }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  babel-preset-fbjs@3.4.0:
+    resolution:
+      { integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow== }
     peerDependencies:
       "@babel/core": ^7.0.0
 
@@ -4300,6 +4631,11 @@ packages:
     peerDependencies:
       esbuild: ">=0.18"
 
+  busboy@1.6.0:
+    resolution:
+      { integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA== }
+    engines: { node: ">=10.16.0" }
+
   bytes@3.0.0:
     resolution:
       { integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw== }
@@ -4335,6 +4671,10 @@ packages:
       { integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ== }
     engines: { node: ">=6" }
 
+  camel-case@4.1.2:
+    resolution:
+      { integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw== }
+
   camelcase-css@2.0.1:
     resolution:
       { integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA== }
@@ -4358,6 +4698,10 @@ packages:
     resolution:
       { integrity: sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw== }
 
+  capital-case@1.0.4:
+    resolution:
+      { integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A== }
+
   chai@4.4.1:
     resolution:
       { integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g== }
@@ -4377,6 +4721,14 @@ packages:
     resolution:
       { integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w== }
     engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
+
+  change-case-all@1.0.15:
+    resolution:
+      { integrity: sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ== }
+
+  change-case@4.1.2:
+    resolution:
+      { integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A== }
 
   char-regex@1.0.2:
     resolution:
@@ -4427,6 +4779,11 @@ packages:
     resolution:
       { integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q== }
 
+  clean-stack@2.2.0:
+    resolution:
+      { integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A== }
+    engines: { node: ">=6" }
+
   cli-cursor@3.1.0:
     resolution:
       { integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw== }
@@ -4442,10 +4799,20 @@ packages:
       { integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg== }
     engines: { node: ">=6" }
 
+  cli-truncate@2.1.0:
+    resolution:
+      { integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg== }
+    engines: { node: ">=8" }
+
   cli-truncate@4.0.0:
     resolution:
       { integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA== }
     engines: { node: ">=18" }
+
+  cli-width@3.0.0:
+    resolution:
+      { integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw== }
+    engines: { node: ">= 10" }
 
   clipboardy@4.0.0:
     resolution:
@@ -4588,6 +4955,10 @@ packages:
       { integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ== }
     engines: { node: ^14.18.0 || >=16.10.0 }
 
+  constant-case@3.0.4:
+    resolution:
+      { integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ== }
+
   convert-source-map@2.0.0:
     resolution:
       { integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg== }
@@ -4612,6 +4983,16 @@ packages:
     resolution:
       { integrity: sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA== }
     engines: { node: ">=4" }
+
+  cosmiconfig@8.3.6:
+    resolution:
+      { integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA== }
+    engines: { node: ">=14" }
+    peerDependencies:
+      typescript: ">=4.9.5"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cosmiconfig@9.0.0:
     resolution:
@@ -4638,6 +5019,11 @@ packages:
   cross-fetch@3.1.8:
     resolution:
       { integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg== }
+
+  cross-inspect@1.0.1:
+    resolution:
+      { integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A== }
+    engines: { node: ">=16.0.0" }
 
   cross-spawn@5.1.0:
     resolution:
@@ -4692,6 +5078,10 @@ packages:
       { integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA== }
     engines: { node: ">= 0.4" }
 
+  dataloader@2.2.2:
+    resolution:
+      { integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g== }
+
   date-fns-tz@3.1.3:
     resolution:
       { integrity: sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA== }
@@ -4705,6 +5095,10 @@ packages:
   dayjs@1.11.13:
     resolution:
       { integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg== }
+
+  debounce@1.2.1:
+    resolution:
+      { integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug== }
 
   debug@2.6.9:
     resolution:
@@ -4809,6 +5203,11 @@ packages:
       { integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw== }
     engines: { node: ">= 0.8" }
 
+  dependency-graph@0.11.0:
+    resolution:
+      { integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg== }
+    engines: { node: ">= 0.6.0" }
+
   destr@2.0.3:
     resolution:
       { integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ== }
@@ -4878,6 +5277,10 @@ packages:
     resolution:
       { integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA== }
 
+  dot-case@3.0.4:
+    resolution:
+      { integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w== }
+
   dotenv@16.0.3:
     resolution:
       { integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ== }
@@ -4887,6 +5290,11 @@ packages:
     resolution:
       { integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg== }
     engines: { node: ">=12" }
+
+  dset@3.1.4:
+    resolution:
+      { integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA== }
+    engines: { node: ">=4" }
 
   duplexify@4.1.3:
     resolution:
@@ -5231,6 +5639,15 @@ packages:
       { integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew== }
     engines: { node: ">=4" }
 
+  extract-files@11.0.0:
+    resolution:
+      { integrity: sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ== }
+    engines: { node: ^12.20 || >= 14.13 }
+
+  fast-decode-uri-component@1.0.1:
+    resolution:
+      { integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg== }
+
   fast-deep-equal@3.1.3:
     resolution:
       { integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q== }
@@ -5251,6 +5668,10 @@ packages:
   fast-levenshtein@2.0.6:
     resolution:
       { integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw== }
+
+  fast-querystring@1.1.2:
+    resolution:
+      { integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg== }
 
   fast-redact@3.5.0:
     resolution:
@@ -5278,6 +5699,14 @@ packages:
     resolution:
       { integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA== }
 
+  fbjs-css-vars@1.0.2:
+    resolution:
+      { integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ== }
+
+  fbjs@3.0.5:
+    resolution:
+      { integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg== }
+
   fdir@6.3.0:
     resolution:
       { integrity: sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ== }
@@ -5286,6 +5715,11 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@3.2.0:
+    resolution:
+      { integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg== }
+    engines: { node: ">=8" }
 
   file-entry-cache@6.0.1:
     resolution:
@@ -5547,12 +5981,36 @@ packages:
     resolution:
       { integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag== }
 
+  graphql-config@5.1.3:
+    resolution:
+      { integrity: sha512-RBhejsPjrNSuwtckRlilWzLVt2j8itl74W9Gke1KejDTz7oaA5kVd6wRn9zK9TS5mcmIYGxf7zN7a1ORMdxp1Q== }
+    engines: { node: ">= 16.0.0" }
+    peerDependencies:
+      cosmiconfig-toml-loader: ^1.0.0
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      cosmiconfig-toml-loader:
+        optional: true
+
+  graphql-request@6.1.0:
+    resolution:
+      { integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw== }
+    peerDependencies:
+      graphql: 14 - 16
+
   graphql-tag@2.12.6:
     resolution:
       { integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg== }
     engines: { node: ">=10" }
     peerDependencies:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  graphql-ws@5.16.0:
+    resolution:
+      { integrity: sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A== }
+    engines: { node: ">=10" }
+    peerDependencies:
+      graphql: ">=0.11 <=16"
 
   graphql@16.9.0:
     resolution:
@@ -5605,6 +6063,10 @@ packages:
       { integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ== }
     engines: { node: ">= 0.4" }
 
+  header-case@2.0.4:
+    resolution:
+      { integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q== }
+
   hermes-estree@0.22.0:
     resolution:
       { integrity: sha512-FLBt5X9OfA8BERUdc6aZS36Xz3rRuB0Y/mfocSADWEJfomc1xfene33GdyAmtTkKTBXTN/EgAy+rjTKkkZJHlw== }
@@ -5638,6 +6100,11 @@ packages:
       { integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ== }
     engines: { node: ">= 0.8" }
 
+  http-proxy-agent@7.0.2:
+    resolution:
+      { integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig== }
+    engines: { node: ">= 14" }
+
   http-shutdown@1.2.2:
     resolution:
       { integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw== }
@@ -5647,6 +6114,11 @@ packages:
     resolution:
       { integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA== }
     engines: { node: ">= 6" }
+
+  https-proxy-agent@7.0.5:
+    resolution:
+      { integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw== }
+    engines: { node: ">= 14" }
 
   human-id@1.0.2:
     resolution:
@@ -5704,6 +6176,11 @@ packages:
     resolution:
       { integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ== }
 
+  immutable@3.7.6:
+    resolution:
+      { integrity: sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw== }
+    engines: { node: ">=0.8.0" }
+
   import-fresh@2.0.0:
     resolution:
       { integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg== }
@@ -5713,6 +6190,11 @@ packages:
     resolution:
       { integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw== }
     engines: { node: ">=6" }
+
+  import-from@4.0.0:
+    resolution:
+      { integrity: sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ== }
+    engines: { node: ">=12.2" }
 
   import-local@3.2.0:
     resolution:
@@ -5724,6 +6206,11 @@ packages:
     resolution:
       { integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA== }
     engines: { node: ">=0.8.19" }
+
+  indent-string@4.0.0:
+    resolution:
+      { integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg== }
+    engines: { node: ">=8" }
 
   inflight@1.0.6:
     resolution:
@@ -5738,6 +6225,11 @@ packages:
     resolution:
       { integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew== }
 
+  inquirer@8.2.6:
+    resolution:
+      { integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg== }
+    engines: { node: ">=12.0.0" }
+
   internal-slot@1.0.7:
     resolution:
       { integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g== }
@@ -5750,6 +6242,11 @@ packages:
   iron-webcrypto@1.2.1:
     resolution:
       { integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg== }
+
+  is-absolute@1.0.0:
+    resolution:
+      { integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA== }
+    engines: { node: ">=0.10.0" }
 
   is-array-buffer@3.0.4:
     resolution:
@@ -5866,6 +6363,10 @@ packages:
       { integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w== }
     engines: { node: ">=8" }
 
+  is-lower-case@2.0.2:
+    resolution:
+      { integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ== }
+
   is-module@1.0.0:
     resolution:
       { integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g== }
@@ -5910,6 +6411,11 @@ packages:
       { integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA== }
     engines: { node: ">=0.10.0" }
 
+  is-relative@1.0.0:
+    resolution:
+      { integrity: sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA== }
+    engines: { node: ">=0.10.0" }
+
   is-shared-array-buffer@1.0.3:
     resolution:
       { integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg== }
@@ -5949,10 +6455,19 @@ packages:
     resolution:
       { integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA== }
 
+  is-unc-path@1.0.0:
+    resolution:
+      { integrity: sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ== }
+    engines: { node: ">=0.10.0" }
+
   is-unicode-supported@0.1.0:
     resolution:
       { integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw== }
     engines: { node: ">=10" }
+
+  is-upper-case@2.0.2:
+    resolution:
+      { integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ== }
 
   is-weakref@1.0.2:
     resolution:
@@ -6003,6 +6518,12 @@ packages:
   isomorphic-unfetch@3.1.0:
     resolution:
       { integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q== }
+
+  isomorphic-ws@5.0.0:
+    resolution:
+      { integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw== }
+    peerDependencies:
+      ws: "*"
 
   isows@1.0.3:
     resolution:
@@ -6216,9 +6737,18 @@ packages:
       { integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w== }
     hasBin: true
 
+  jiti@2.3.3:
+    resolution:
+      { integrity: sha512-EX4oNDwcXSivPrw2qKH2LB5PoFxEvgtv2JgwW0bU858HoLQ+kutSvjLMUqBd0PeJYEinLWhoI9Ol0eYMqj/wNQ== }
+    hasBin: true
+
   joi@17.13.3:
     resolution:
       { integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA== }
+
+  jose@5.9.4:
+    resolution:
+      { integrity: sha512-WBBl6au1qg6OHj67yCffCgFR3BADJBXN8MdRvCgJDuMv3driV2nHr7jdGvaKX9IolosAsn+M0XRArqLXUhyJHQ== }
 
   joycon@3.1.1:
     resolution:
@@ -6306,6 +6836,11 @@ packages:
     resolution:
       { integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw== }
 
+  json-to-pretty-yaml@1.2.2:
+    resolution:
+      { integrity: sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A== }
+    engines: { node: ">= 0.2.0" }
+
   json5@2.2.3:
     resolution:
       { integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg== }
@@ -6390,6 +6925,16 @@ packages:
     resolution:
       { integrity: sha512-7/HamOm5YD9Wb7CFgAZkKgVPA96WwhcTQoqtm2VTZGVbVVn3IWKRBTgrU7cchA3Q8k9iCsG8Osoi9GX4JsGM9g== }
     hasBin: true
+
+  listr2@4.0.5:
+    resolution:
+      { integrity: sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA== }
+    engines: { node: ">=12" }
+    peerDependencies:
+      enquirer: ">= 2.3.0 < 3"
+    peerDependenciesMeta:
+      enquirer:
+        optional: true
 
   listr2@8.2.3:
     resolution:
@@ -6479,6 +7024,11 @@ packages:
       { integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg== }
     engines: { node: ">=10" }
 
+  log-update@4.0.0:
+    resolution:
+      { integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg== }
+    engines: { node: ">=10" }
+
   log-update@6.0.0:
     resolution:
       { integrity: sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw== }
@@ -6497,6 +7047,14 @@ packages:
   loupe@2.3.7:
     resolution:
       { integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA== }
+
+  lower-case-first@2.0.2:
+    resolution:
+      { integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg== }
+
+  lower-case@2.0.2:
+    resolution:
+      { integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg== }
 
   lru-cache@10.4.3:
     resolution:
@@ -6541,6 +7099,11 @@ packages:
     resolution:
       { integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg== }
 
+  map-cache@0.2.2:
+    resolution:
+      { integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg== }
+    engines: { node: ">=0.10.0" }
+
   marky@1.2.5:
     resolution:
       { integrity: sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q== }
@@ -6565,6 +7128,16 @@ packages:
     resolution:
       { integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg== }
     engines: { node: ">= 8" }
+
+  meros@1.3.0:
+    resolution:
+      { integrity: sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w== }
+    engines: { node: ">=13" }
+    peerDependencies:
+      "@types/node": ">=13"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
 
   mersenne-twister@1.1.0:
     resolution:
@@ -6790,6 +7363,10 @@ packages:
     resolution:
       { integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg== }
 
+  mute-stream@0.0.8:
+    resolution:
+      { integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA== }
+
   mz@2.7.0:
     resolution:
       { integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q== }
@@ -6816,6 +7393,10 @@ packages:
   neo-async@2.6.2:
     resolution:
       { integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw== }
+
+  no-case@3.0.4:
+    resolution:
+      { integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg== }
 
   nocache@3.0.4:
     resolution:
@@ -6884,6 +7465,11 @@ packages:
     resolution:
       { integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw== }
     engines: { node: ">=0.12.0" }
+
+  normalize-path@2.1.1:
+    resolution:
+      { integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w== }
+    engines: { node: ">=0.10.0" }
 
   normalize-path@3.0.0:
     resolution:
@@ -7057,6 +7643,11 @@ packages:
       { integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw== }
     engines: { node: ">=6" }
 
+  p-map@4.0.0:
+    resolution:
+      { integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ== }
+    engines: { node: ">=10" }
+
   p-try@2.2.0:
     resolution:
       { integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ== }
@@ -7066,10 +7657,19 @@ packages:
     resolution:
       { integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw== }
 
+  param-case@3.0.4:
+    resolution:
+      { integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A== }
+
   parent-module@1.0.1:
     resolution:
       { integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g== }
     engines: { node: ">=6" }
+
+  parse-filepath@1.0.2:
+    resolution:
+      { integrity: sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q== }
+    engines: { node: ">=0.8" }
 
   parse-json@4.0.0:
     resolution:
@@ -7085,6 +7685,14 @@ packages:
     resolution:
       { integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ== }
     engines: { node: ">= 0.8" }
+
+  pascal-case@3.1.2:
+    resolution:
+      { integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g== }
+
+  path-case@3.0.4:
+    resolution:
+      { integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg== }
 
   path-exists@3.0.0:
     resolution:
@@ -7114,6 +7722,16 @@ packages:
   path-parse@1.0.7:
     resolution:
       { integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw== }
+
+  path-root-regex@0.1.2:
+    resolution:
+      { integrity: sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ== }
+    engines: { node: ">=0.10.0" }
+
+  path-root@0.1.1:
+    resolution:
+      { integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg== }
+    engines: { node: ">=0.10.0" }
 
   path-scurry@1.11.1:
     resolution:
@@ -7412,6 +8030,10 @@ packages:
     resolution:
       { integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA== }
     engines: { node: ">=0.4.0" }
+
+  promise@7.3.1:
+    resolution:
+      { integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg== }
 
   promise@8.3.0:
     resolution:
@@ -7730,9 +8352,25 @@ packages:
       react:
         optional: true
 
+  relay-runtime@12.0.0:
+    resolution:
+      { integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug== }
+
+  remedial@1.0.8:
+    resolution:
+      { integrity: sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg== }
+
   remove-accents@0.5.0:
     resolution:
       { integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A== }
+
+  remove-trailing-separator@1.1.0:
+    resolution:
+      { integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw== }
+
+  remove-trailing-spaces@1.0.8:
+    resolution:
+      { integrity: sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA== }
 
   require-directory@2.1.1:
     resolution:
@@ -7826,6 +8464,11 @@ packages:
     engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
 
+  run-async@2.4.1:
+    resolution:
+      { integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ== }
+    engines: { node: ">=0.12.0" }
+
   run-parallel@1.2.0:
     resolution:
       { integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA== }
@@ -7869,6 +8512,10 @@ packages:
     resolution:
       { integrity: sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA== }
 
+  scuid@1.1.0:
+    resolution:
+      { integrity: sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg== }
+
   selfsigned@2.4.1:
     resolution:
       { integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q== }
@@ -7894,6 +8541,10 @@ packages:
     resolution:
       { integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg== }
     engines: { node: ">= 0.8.0" }
+
+  sentence-case@3.0.4:
+    resolution:
+      { integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg== }
 
   serialize-error@2.1.0:
     resolution:
@@ -7922,6 +8573,10 @@ packages:
     resolution:
       { integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ== }
     engines: { node: ">= 0.4" }
+
+  setimmediate@1.0.5:
+    resolution:
+      { integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA== }
 
   setprototypeof@1.2.0:
     resolution:
@@ -7988,6 +8643,10 @@ packages:
       { integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw== }
     engines: { node: ">=14" }
 
+  signedsource@1.0.0:
+    resolution:
+      { integrity: sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww== }
+
   simple-concat@1.0.1:
     resolution:
       { integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q== }
@@ -8014,6 +8673,16 @@ packages:
       { integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ== }
     engines: { node: ">=6" }
 
+  slice-ansi@3.0.0:
+    resolution:
+      { integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ== }
+    engines: { node: ">=8" }
+
+  slice-ansi@4.0.0:
+    resolution:
+      { integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ== }
+    engines: { node: ">=10" }
+
   slice-ansi@5.0.0:
     resolution:
       { integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ== }
@@ -8027,6 +8696,10 @@ packages:
   smob@1.5.0:
     resolution:
       { integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig== }
+
+  snake-case@3.0.4:
+    resolution:
+      { integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg== }
 
   sonic-boom@2.8.0:
     resolution:
@@ -8083,6 +8756,10 @@ packages:
       { integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg== }
     engines: { node: ">= 10.x" }
 
+  sponge-case@1.0.1:
+    resolution:
+      { integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA== }
+
   sprintf-js@1.0.3:
     resolution:
       { integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g== }
@@ -8123,6 +8800,11 @@ packages:
     resolution:
       { integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ== }
 
+  streamsearch@1.1.0:
+    resolution:
+      { integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg== }
+    engines: { node: ">=10.0.0" }
+
   streamx@2.19.0:
     resolution:
       { integrity: sha512-5z6CNR4gtkPbwlxyEqoDGDmWIzoNJqCBt4Eac1ICP9YaIT08ct712cFj0u1rx4F8luAuL+3Qc+RFIdI4OX00kg== }
@@ -8136,6 +8818,10 @@ packages:
     resolution:
       { integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q== }
     engines: { node: ">=0.6.19" }
+
+  string-env-interpolation@1.0.1:
+    resolution:
+      { integrity: sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg== }
 
   string-length@4.0.2:
     resolution:
@@ -8286,6 +8972,10 @@ packages:
       { integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w== }
     engines: { node: ">= 0.4" }
 
+  swap-case@2.0.2:
+    resolution:
+      { integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw== }
+
   symbol-observable@4.0.0:
     resolution:
       { integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ== }
@@ -8389,6 +9079,10 @@ packages:
     resolution:
       { integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ== }
 
+  through@2.3.8:
+    resolution:
+      { integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg== }
+
   tinybench@2.8.0:
     resolution:
       { integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw== }
@@ -8407,6 +9101,10 @@ packages:
     resolution:
       { integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A== }
     engines: { node: ">=14.0.0" }
+
+  title-case@3.0.3:
+    resolution:
+      { integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA== }
 
   tmp@0.0.33:
     resolution:
@@ -8493,6 +9191,10 @@ packages:
         optional: true
       esbuild:
         optional: true
+
+  ts-log@2.2.7:
+    resolution:
+      { integrity: sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg== }
 
   tslib@1.14.1:
     resolution:
@@ -8643,6 +9345,11 @@ packages:
     resolution:
       { integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw== }
 
+  unc-path-regex@0.1.2:
+    resolution:
+      { integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg== }
+    engines: { node: ">=0.10.0" }
+
   unconfig@0.3.13:
     resolution:
       { integrity: sha512-N9Ph5NC4+sqtcOjPfHrRcHekBCadCXWTBzp2VYYbySOHW0PfD9XLCeXshTXjkPYwLrBr9AtSeU0CZmkYECJhng== }
@@ -8697,6 +9404,11 @@ packages:
     resolution:
       { integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw== }
     engines: { node: ">= 10.0.0" }
+
+  unixify@1.0.0:
+    resolution:
+      { integrity: sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg== }
+    engines: { node: ">=0.10.0" }
 
   unpipe@1.0.0:
     resolution:
@@ -8769,6 +9481,14 @@ packages:
     peerDependencies:
       browserslist: ">= 4.21.0"
 
+  upper-case-first@2.0.2:
+    resolution:
+      { integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg== }
+
+  upper-case@2.0.2:
+    resolution:
+      { integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg== }
+
   uqr@0.1.2:
     resolution:
       { integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA== }
@@ -8776,6 +9496,10 @@ packages:
   uri-js@4.4.1:
     resolution:
       { integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg== }
+
+  urlpattern-polyfill@10.0.0:
+    resolution:
+      { integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg== }
 
   use-callback-ref@1.3.2:
     resolution:
@@ -8842,6 +9566,11 @@ packages:
         optional: true
       react:
         optional: true
+
+  value-or-promise@1.0.12:
+    resolution:
+      { integrity: sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q== }
+    engines: { node: ">=12" }
 
   vary@1.1.2:
     resolution:
@@ -9207,6 +9936,10 @@ packages:
     resolution:
       { integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g== }
 
+  yaml-ast-parser@0.0.43:
+    resolution:
+      { integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A== }
+
   yaml@2.4.5:
     resolution:
       { integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg== }
@@ -9286,7 +10019,7 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  "@apollo/client@3.11.1(@types/react@18.3.3)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@apollo/client@3.11.1(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
       "@graphql-typed-document-node/core": 3.2.0(graphql@16.9.0)
       "@wry/caches": 1.0.1
@@ -9304,10 +10037,41 @@ snapshots:
       tslib: 2.6.3
       zen-observable-ts: 1.2.5
     optionalDependencies:
+      graphql-ws: 5.16.0(graphql@16.9.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - "@types/react"
+
+  "@ardatan/relay-compiler@12.0.0(graphql@16.9.0)":
+    dependencies:
+      "@babel/core": 7.25.2
+      "@babel/generator": 7.25.5
+      "@babel/parser": 7.25.4
+      "@babel/runtime": 7.24.8
+      "@babel/traverse": 7.25.4
+      "@babel/types": 7.25.6
+      babel-preset-fbjs: 3.4.0(@babel/core@7.25.2)
+      chalk: 4.1.2
+      fb-watchman: 2.0.2
+      fbjs: 3.0.5
+      glob: 7.2.3
+      graphql: 16.9.0
+      immutable: 3.7.6
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      relay-runtime: 12.0.0
+      signedsource: 1.0.0
+      yargs: 15.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@ardatan/sync-fetch@0.0.1":
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   "@babel/code-frame@7.24.7":
     dependencies:
@@ -9613,6 +10377,15 @@ snapshots:
       "@babel/core": 7.25.2
       "@babel/helper-plugin-utils": 7.24.8
       "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.25.2)
+
+  "@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.25.2)":
+    dependencies:
+      "@babel/compat-data": 7.25.4
+      "@babel/core": 7.25.2
+      "@babel/helper-compilation-targets": 7.25.2
+      "@babel/helper-plugin-utils": 7.24.8
+      "@babel/plugin-syntax-object-rest-spread": 7.8.3(@babel/core@7.25.2)
+      "@babel/plugin-transform-parameters": 7.24.7(@babel/core@7.25.2)
 
   "@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.25.2)":
     dependencies:
@@ -10783,6 +11556,431 @@ snapshots:
 
   "@floating-ui/utils@0.2.5": {}
 
+  "@graphql-codegen/add@5.0.3(graphql@16.9.0)":
+    dependencies:
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  "@graphql-codegen/cli@5.0.3(@parcel/watcher@2.4.1)(@types/node@20.14.12)(enquirer@2.4.1)(graphql@16.9.0)(typescript@5.5.4)":
+    dependencies:
+      "@babel/generator": 7.25.5
+      "@babel/template": 7.25.0
+      "@babel/types": 7.25.6
+      "@graphql-codegen/client-preset": 4.4.0(graphql@16.9.0)
+      "@graphql-codegen/core": 4.0.2(graphql@16.9.0)
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-tools/apollo-engine-loader": 8.0.1(graphql@16.9.0)
+      "@graphql-tools/code-file-loader": 8.1.3(graphql@16.9.0)
+      "@graphql-tools/git-loader": 8.0.7(graphql@16.9.0)
+      "@graphql-tools/github-loader": 8.0.1(@types/node@20.14.12)(graphql@16.9.0)
+      "@graphql-tools/graphql-file-loader": 8.0.1(graphql@16.9.0)
+      "@graphql-tools/json-file-loader": 8.0.1(graphql@16.9.0)
+      "@graphql-tools/load": 8.0.2(graphql@16.9.0)
+      "@graphql-tools/prisma-loader": 8.0.4(@types/node@20.14.12)(graphql@16.9.0)
+      "@graphql-tools/url-loader": 8.0.2(@types/node@20.14.12)(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@whatwg-node/fetch": 0.9.21
+      chalk: 4.1.2
+      cosmiconfig: 8.3.6(typescript@5.5.4)
+      debounce: 1.2.1
+      detect-indent: 6.1.0
+      graphql: 16.9.0
+      graphql-config: 5.1.3(@types/node@20.14.12)(graphql@16.9.0)(typescript@5.5.4)
+      inquirer: 8.2.6
+      is-glob: 4.0.3
+      jiti: 1.21.6
+      json-to-pretty-yaml: 1.2.2
+      listr2: 4.0.5(enquirer@2.4.1)
+      log-symbols: 4.1.0
+      micromatch: 4.0.7
+      shell-quote: 1.8.1
+      string-env-interpolation: 1.0.1
+      ts-log: 2.2.7
+      tslib: 2.6.3
+      yaml: 2.4.5
+      yargs: 17.7.2
+    optionalDependencies:
+      "@parcel/watcher": 2.4.1
+    transitivePeerDependencies:
+      - "@types/node"
+      - bufferutil
+      - cosmiconfig-toml-loader
+      - encoding
+      - enquirer
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  "@graphql-codegen/client-preset@4.4.0(graphql@16.9.0)":
+    dependencies:
+      "@babel/helper-plugin-utils": 7.24.8
+      "@babel/template": 7.25.0
+      "@graphql-codegen/add": 5.0.3(graphql@16.9.0)
+      "@graphql-codegen/gql-tag-operations": 4.0.10(graphql@16.9.0)
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-codegen/typed-document-node": 5.0.10(graphql@16.9.0)
+      "@graphql-codegen/typescript": 4.1.0(graphql@16.9.0)
+      "@graphql-codegen/typescript-operations": 4.3.0(graphql@16.9.0)
+      "@graphql-codegen/visitor-plugin-common": 5.4.0(graphql@16.9.0)
+      "@graphql-tools/documents": 1.0.1(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@graphql-typed-document-node/core": 3.2.0(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@graphql-codegen/core@4.0.2(graphql@16.9.0)":
+    dependencies:
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-tools/schema": 10.0.6(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  "@graphql-codegen/gql-tag-operations@4.0.10(graphql@16.9.0)":
+    dependencies:
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-codegen/visitor-plugin-common": 5.4.0(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      auto-bind: 4.0.0
+      graphql: 16.9.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@graphql-codegen/plugin-helpers@5.0.4(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      change-case-all: 1.0.15
+      common-tags: 1.8.2
+      graphql: 16.9.0
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.6.3
+
+  "@graphql-codegen/schema-ast@4.1.0(graphql@16.9.0)":
+    dependencies:
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  "@graphql-codegen/typed-document-node@5.0.10(graphql@16.9.0)":
+    dependencies:
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-codegen/visitor-plugin-common": 5.4.0(graphql@16.9.0)
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      graphql: 16.9.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@graphql-codegen/typescript-operations@4.3.0(graphql@16.9.0)":
+    dependencies:
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-codegen/typescript": 4.1.0(graphql@16.9.0)
+      "@graphql-codegen/visitor-plugin-common": 5.4.0(graphql@16.9.0)
+      auto-bind: 4.0.0
+      graphql: 16.9.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@graphql-codegen/typescript@4.1.0(graphql@16.9.0)":
+    dependencies:
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-codegen/schema-ast": 4.1.0(graphql@16.9.0)
+      "@graphql-codegen/visitor-plugin-common": 5.4.0(graphql@16.9.0)
+      auto-bind: 4.0.0
+      graphql: 16.9.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@graphql-codegen/visitor-plugin-common@5.4.0(graphql@16.9.0)":
+    dependencies:
+      "@graphql-codegen/plugin-helpers": 5.0.4(graphql@16.9.0)
+      "@graphql-tools/optimize": 2.0.0(graphql@16.9.0)
+      "@graphql-tools/relay-operation-optimizer": 7.0.1(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      dependency-graph: 0.11.0
+      graphql: 16.9.0
+      graphql-tag: 2.12.6(graphql@16.9.0)
+      parse-filepath: 1.0.2
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@graphql-tools/apollo-engine-loader@8.0.1(graphql@16.9.0)":
+    dependencies:
+      "@ardatan/sync-fetch": 0.0.1
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@whatwg-node/fetch": 0.9.21
+      graphql: 16.9.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  "@graphql-tools/batch-execute@9.0.4(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      dataloader: 2.2.2
+      graphql: 16.9.0
+      tslib: 2.6.3
+      value-or-promise: 1.0.12
+
+  "@graphql-tools/code-file-loader@8.1.3(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/graphql-tag-pluck": 8.3.2(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      globby: 11.1.0
+      graphql: 16.9.0
+      tslib: 2.6.3
+      unixify: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  "@graphql-tools/delegate@10.0.21(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/batch-execute": 9.0.4(graphql@16.9.0)
+      "@graphql-tools/executor": 1.3.1(graphql@16.9.0)
+      "@graphql-tools/schema": 10.0.6(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@repeaterjs/repeater": 3.0.6
+      dataloader: 2.2.2
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  "@graphql-tools/documents@1.0.1(graphql@16.9.0)":
+    dependencies:
+      graphql: 16.9.0
+      lodash.sortby: 4.7.0
+      tslib: 2.6.3
+
+  "@graphql-tools/executor-graphql-ws@1.3.0(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@types/ws": 8.5.12
+      graphql: 16.9.0
+      graphql-ws: 5.16.0(graphql@16.9.0)
+      isomorphic-ws: 5.0.0(ws@8.17.1)
+      tslib: 2.6.3
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  "@graphql-tools/executor-http@1.1.6(@types/node@20.14.12)(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@repeaterjs/repeater": 3.0.6
+      "@whatwg-node/fetch": 0.9.21
+      extract-files: 11.0.0
+      graphql: 16.9.0
+      meros: 1.3.0(@types/node@20.14.12)
+      tslib: 2.6.3
+      value-or-promise: 1.0.12
+    transitivePeerDependencies:
+      - "@types/node"
+
+  "@graphql-tools/executor-legacy-ws@1.1.0(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@types/ws": 8.5.12
+      graphql: 16.9.0
+      isomorphic-ws: 5.0.0(ws@8.17.1)
+      tslib: 2.6.3
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  "@graphql-tools/executor@1.3.1(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@graphql-typed-document-node/core": 3.2.0(graphql@16.9.0)
+      "@repeaterjs/repeater": 3.0.6
+      graphql: 16.9.0
+      tslib: 2.6.3
+      value-or-promise: 1.0.12
+
+  "@graphql-tools/git-loader@8.0.7(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/graphql-tag-pluck": 8.3.2(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      is-glob: 4.0.3
+      micromatch: 4.0.7
+      tslib: 2.6.3
+      unixify: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  "@graphql-tools/github-loader@8.0.1(@types/node@20.14.12)(graphql@16.9.0)":
+    dependencies:
+      "@ardatan/sync-fetch": 0.0.1
+      "@graphql-tools/executor-http": 1.1.6(@types/node@20.14.12)(graphql@16.9.0)
+      "@graphql-tools/graphql-tag-pluck": 8.3.2(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@whatwg-node/fetch": 0.9.21
+      graphql: 16.9.0
+      tslib: 2.6.3
+      value-or-promise: 1.0.12
+    transitivePeerDependencies:
+      - "@types/node"
+      - encoding
+      - supports-color
+
+  "@graphql-tools/graphql-file-loader@8.0.1(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/import": 7.0.1(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      globby: 11.1.0
+      graphql: 16.9.0
+      tslib: 2.6.3
+      unixify: 1.0.0
+
+  "@graphql-tools/graphql-tag-pluck@8.3.2(graphql@16.9.0)":
+    dependencies:
+      "@babel/core": 7.25.2
+      "@babel/parser": 7.25.4
+      "@babel/plugin-syntax-import-assertions": 7.24.7(@babel/core@7.25.2)
+      "@babel/traverse": 7.25.4
+      "@babel/types": 7.25.6
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - supports-color
+
+  "@graphql-tools/import@7.0.1(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      resolve-from: 5.0.0
+      tslib: 2.6.3
+
+  "@graphql-tools/json-file-loader@8.0.1(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      globby: 11.1.0
+      graphql: 16.9.0
+      tslib: 2.6.3
+      unixify: 1.0.0
+
+  "@graphql-tools/load@8.0.2(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/schema": 10.0.6(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      p-limit: 3.1.0
+      tslib: 2.6.3
+
+  "@graphql-tools/merge@9.0.7(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  "@graphql-tools/optimize@2.0.0(graphql@16.9.0)":
+    dependencies:
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  "@graphql-tools/prisma-loader@8.0.4(@types/node@20.14.12)(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/url-loader": 8.0.2(@types/node@20.14.12)(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@types/js-yaml": 4.0.9
+      "@whatwg-node/fetch": 0.9.21
+      chalk: 4.1.2
+      debug: 4.3.5
+      dotenv: 16.4.5
+      graphql: 16.9.0
+      graphql-request: 6.1.0(graphql@16.9.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.5
+      jose: 5.9.4
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      scuid: 1.1.0
+      tslib: 2.6.3
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - "@types/node"
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  "@graphql-tools/relay-operation-optimizer@7.0.1(graphql@16.9.0)":
+    dependencies:
+      "@ardatan/relay-compiler": 12.0.0(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@graphql-tools/schema@10.0.6(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/merge": 9.0.7(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+      value-or-promise: 1.0.12
+
+  "@graphql-tools/url-loader@8.0.2(@types/node@20.14.12)(graphql@16.9.0)":
+    dependencies:
+      "@ardatan/sync-fetch": 0.0.1
+      "@graphql-tools/delegate": 10.0.21(graphql@16.9.0)
+      "@graphql-tools/executor-graphql-ws": 1.3.0(graphql@16.9.0)
+      "@graphql-tools/executor-http": 1.1.6(@types/node@20.14.12)(graphql@16.9.0)
+      "@graphql-tools/executor-legacy-ws": 1.1.0(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      "@graphql-tools/wrap": 10.0.5(graphql@16.9.0)
+      "@types/ws": 8.5.12
+      "@whatwg-node/fetch": 0.9.21
+      graphql: 16.9.0
+      isomorphic-ws: 5.0.0(ws@8.17.1)
+      tslib: 2.6.3
+      value-or-promise: 1.0.12
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - "@types/node"
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  "@graphql-tools/utils@10.5.4(graphql@16.9.0)":
+    dependencies:
+      "@graphql-typed-document-node/core": 3.2.0(graphql@16.9.0)
+      cross-inspect: 1.0.1
+      dset: 3.1.4
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  "@graphql-tools/wrap@10.0.5(graphql@16.9.0)":
+    dependencies:
+      "@graphql-tools/delegate": 10.0.21(graphql@16.9.0)
+      "@graphql-tools/schema": 10.0.6(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+      value-or-promise: 1.0.12
+
   "@graphql-typed-document-node/core@3.2.0(graphql@16.9.0)":
     dependencies:
       graphql: 16.9.0
@@ -11034,6 +12232,8 @@ snapshots:
     dependencies:
       "@jridgewell/resolve-uri": 3.1.2
       "@jridgewell/sourcemap-codec": 1.5.0
+
+  "@kamilkisiela/fast-url-parser@1.1.4": {}
 
   "@lit-labs/ssr-dom-shim@1.2.0": {}
 
@@ -11601,6 +12801,8 @@ snapshots:
     optional: true
 
   "@remix-run/router@1.18.0": {}
+
+  "@repeaterjs/repeater@3.0.6": {}
 
   "@rollup/plugin-babel@5.3.1(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@2.79.1)":
     dependencies:
@@ -13007,6 +14209,8 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
+  "@types/js-yaml@4.0.9": {}
+
   "@types/ms@0.7.34": {}
 
   "@types/node-forge@1.3.11":
@@ -13041,6 +14245,10 @@ snapshots:
   "@types/stack-utils@2.0.3": {}
 
   "@types/trusted-types@2.0.7": {}
+
+  "@types/ws@8.5.12":
+    dependencies:
+      "@types/node": 20.14.12
 
   "@types/yargs-parser@21.0.3": {}
 
@@ -13672,6 +14880,18 @@ snapshots:
       "@walletconnect/window-getters": 1.0.1
       tslib: 1.14.1
 
+  "@whatwg-node/fetch@0.9.21":
+    dependencies:
+      "@whatwg-node/node-fetch": 0.5.26
+      urlpattern-polyfill: 10.0.0
+
+  "@whatwg-node/node-fetch@0.5.26":
+    dependencies:
+      "@kamilkisiela/fast-url-parser": 1.1.4
+      busboy: 1.6.0
+      fast-querystring: 1.1.2
+      tslib: 2.6.3
+
   "@wry/caches@1.0.1":
     dependencies:
       tslib: 2.6.3
@@ -13730,6 +14950,17 @@ snapshots:
       debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.1:
+    dependencies:
+      debug: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
 
   ajv@6.12.6:
     dependencies:
@@ -13828,6 +15059,8 @@ snapshots:
 
   astral-regex@1.0.0: {}
 
+  astral-regex@2.0.0: {}
+
   async-limiter@1.0.1: {}
 
   async-mutex@0.2.6:
@@ -13839,6 +15072,8 @@ snapshots:
   at-least-node@1.0.0: {}
 
   atomic-sleep@1.0.0: {}
+
+  auto-bind@4.0.0: {}
 
   autoprefixer@10.4.19(postcss@8.4.39):
     dependencies:
@@ -13932,6 +15167,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
+
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.25.2):
     dependencies:
       "@babel/plugin-syntax-flow": 7.24.7(@babel/core@7.25.2)
@@ -13970,6 +15207,39 @@ snapshots:
       "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.25.2)
       "@babel/plugin-syntax-top-level-await": 7.14.5(@babel/core@7.25.2)
     optional: true
+
+  babel-preset-fbjs@3.4.0(@babel/core@7.25.2):
+    dependencies:
+      "@babel/core": 7.25.2
+      "@babel/plugin-proposal-class-properties": 7.18.6(@babel/core@7.25.2)
+      "@babel/plugin-proposal-object-rest-spread": 7.20.7(@babel/core@7.25.2)
+      "@babel/plugin-syntax-class-properties": 7.12.13(@babel/core@7.25.2)
+      "@babel/plugin-syntax-flow": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-syntax-jsx": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-syntax-object-rest-spread": 7.8.3(@babel/core@7.25.2)
+      "@babel/plugin-transform-arrow-functions": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-block-scoped-functions": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-block-scoping": 7.25.0(@babel/core@7.25.2)
+      "@babel/plugin-transform-classes": 7.25.4(@babel/core@7.25.2)
+      "@babel/plugin-transform-computed-properties": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-destructuring": 7.24.8(@babel/core@7.25.2)
+      "@babel/plugin-transform-flow-strip-types": 7.25.2(@babel/core@7.25.2)
+      "@babel/plugin-transform-for-of": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-function-name": 7.25.1(@babel/core@7.25.2)
+      "@babel/plugin-transform-literals": 7.25.2(@babel/core@7.25.2)
+      "@babel/plugin-transform-member-expression-literals": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-modules-commonjs": 7.24.8(@babel/core@7.25.2)
+      "@babel/plugin-transform-object-super": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-parameters": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-property-literals": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-react-display-name": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-react-jsx": 7.25.2(@babel/core@7.25.2)
+      "@babel/plugin-transform-shorthand-properties": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-spread": 7.24.7(@babel/core@7.25.2)
+      "@babel/plugin-transform-template-literals": 7.24.7(@babel/core@7.25.2)
+      babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
+    transitivePeerDependencies:
+      - supports-color
 
   babel-preset-jest@29.6.3(@babel/core@7.24.9):
     dependencies:
@@ -14079,6 +15349,10 @@ snapshots:
       esbuild: 0.23.0
       load-tsconfig: 0.2.5
 
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
   bytes@3.0.0: {}
 
   cac@6.7.14: {}
@@ -14103,6 +15377,11 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camel-case@4.1.2:
+    dependencies:
+      pascal-case: 3.1.2
+      tslib: 2.6.3
+
   camelcase-css@2.0.1: {}
 
   camelcase@5.3.1: {}
@@ -14112,6 +15391,12 @@ snapshots:
   caniuse-lite@1.0.30001643: {}
 
   caniuse-lite@1.0.30001653: {}
+
+  capital-case@1.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.3
+      upper-case-first: 2.0.2
 
   chai@4.4.1:
     dependencies:
@@ -14135,6 +15420,34 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.3.0: {}
+
+  change-case-all@1.0.15:
+    dependencies:
+      change-case: 4.1.2
+      is-lower-case: 2.0.2
+      is-upper-case: 2.0.2
+      lower-case: 2.0.2
+      lower-case-first: 2.0.2
+      sponge-case: 1.0.1
+      swap-case: 2.0.2
+      title-case: 3.0.3
+      upper-case: 2.0.2
+      upper-case-first: 2.0.2
+
+  change-case@4.1.2:
+    dependencies:
+      camel-case: 4.1.2
+      capital-case: 1.0.4
+      constant-case: 3.0.4
+      dot-case: 3.0.4
+      header-case: 2.0.4
+      no-case: 3.0.4
+      param-case: 3.0.4
+      pascal-case: 3.1.2
+      path-case: 3.0.4
+      sentence-case: 3.0.4
+      snake-case: 3.0.4
+      tslib: 2.6.3
 
   char-regex@1.0.2: {}
 
@@ -14188,6 +15501,8 @@ snapshots:
 
   cjs-module-lexer@1.3.1: {}
 
+  clean-stack@2.2.0: {}
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -14198,10 +15513,17 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cli-truncate@2.1.0:
+    dependencies:
+      slice-ansi: 3.0.0
+      string-width: 4.2.3
+
   cli-truncate@4.0.0:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
+
+  cli-width@3.0.0: {}
 
   clipboardy@4.0.0:
     dependencies:
@@ -14310,6 +15632,12 @@ snapshots:
 
   consola@3.2.3: {}
 
+  constant-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.3
+      upper-case: 2.0.2
+
   convert-source-map@2.0.0: {}
 
   cookie-es@1.2.1: {}
@@ -14330,6 +15658,15 @@ snapshots:
       is-directory: 0.3.1
       js-yaml: 3.14.1
       parse-json: 4.0.0
+
+  cosmiconfig@8.3.6(typescript@5.5.4):
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.5.4
 
   cosmiconfig@9.0.0(typescript@5.5.4):
     dependencies:
@@ -14362,6 +15699,10 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  cross-inspect@1.0.1:
+    dependencies:
+      tslib: 2.6.3
 
   cross-spawn@5.1.0:
     dependencies:
@@ -14403,6 +15744,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  dataloader@2.2.2: {}
+
   date-fns-tz@3.1.3(date-fns@3.6.0):
     dependencies:
       date-fns: 3.6.0
@@ -14410,6 +15753,8 @@ snapshots:
   date-fns@3.6.0: {}
 
   dayjs@1.11.13: {}
+
+  debounce@1.2.1: {}
 
   debug@2.6.9:
     dependencies:
@@ -14474,6 +15819,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dependency-graph@0.11.0: {}
+
   destr@2.0.3: {}
 
   destroy@1.2.0: {}
@@ -14511,9 +15858,16 @@ snapshots:
       "@babel/runtime": 7.24.8
       csstype: 3.1.3
 
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.3
+
   dotenv@16.0.3: {}
 
   dotenv@16.4.5: {}
+
+  dset@3.1.4: {}
 
   duplexify@4.1.3:
     dependencies:
@@ -14912,6 +16266,10 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
+  extract-files@11.0.0: {}
+
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -14927,6 +16285,10 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-redact@3.5.0: {}
 
@@ -14946,9 +16308,27 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
+  fbjs-css-vars@1.0.2: {}
+
+  fbjs@3.0.5:
+    dependencies:
+      cross-fetch: 3.1.8
+      fbjs-css-vars: 1.0.2
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      promise: 7.3.1
+      setimmediate: 1.0.5
+      ua-parser-js: 1.0.38
+    transitivePeerDependencies:
+      - encoding
+
   fdir@6.3.0(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  figures@3.2.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -15183,10 +16563,43 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql-config@5.1.3(@types/node@20.14.12)(graphql@16.9.0)(typescript@5.5.4):
+    dependencies:
+      "@graphql-tools/graphql-file-loader": 8.0.1(graphql@16.9.0)
+      "@graphql-tools/json-file-loader": 8.0.1(graphql@16.9.0)
+      "@graphql-tools/load": 8.0.2(graphql@16.9.0)
+      "@graphql-tools/merge": 9.0.7(graphql@16.9.0)
+      "@graphql-tools/url-loader": 8.0.2(@types/node@20.14.12)(graphql@16.9.0)
+      "@graphql-tools/utils": 10.5.4(graphql@16.9.0)
+      cosmiconfig: 8.3.6(typescript@5.5.4)
+      graphql: 16.9.0
+      jiti: 2.3.3
+      minimatch: 9.0.5
+      string-env-interpolation: 1.0.1
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - "@types/node"
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  graphql-request@6.1.0(graphql@16.9.0):
+    dependencies:
+      "@graphql-typed-document-node/core": 3.2.0(graphql@16.9.0)
+      cross-fetch: 3.1.8
+      graphql: 16.9.0
+    transitivePeerDependencies:
+      - encoding
+
   graphql-tag@2.12.6(graphql@16.9.0):
     dependencies:
       graphql: 16.9.0
       tslib: 2.6.3
+
+  graphql-ws@5.16.0(graphql@16.9.0):
+    dependencies:
+      graphql: 16.9.0
 
   graphql@16.9.0: {}
 
@@ -15232,6 +16645,11 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  header-case@2.0.4:
+    dependencies:
+      capital-case: 1.0.4
+      tslib: 2.6.3
+
   hermes-estree@0.22.0: {}
 
   hermes-estree@0.23.0: {}
@@ -15260,11 +16678,25 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+
   http-shutdown@1.2.2: {}
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.5:
+    dependencies:
+      agent-base: 7.1.1
       debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
@@ -15297,6 +16729,8 @@ snapshots:
 
   immediate@3.0.6: {}
 
+  immutable@3.7.6: {}
+
   import-fresh@2.0.0:
     dependencies:
       caller-path: 2.0.0
@@ -15307,12 +16741,16 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-from@4.0.0: {}
+
   import-local@3.2.0:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -15322,6 +16760,24 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  inquirer@8.2.6:
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      external-editor: 3.1.0
+      figures: 3.2.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.8.1
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+      wrap-ansi: 6.2.0
 
   internal-slot@1.0.7:
     dependencies:
@@ -15334,6 +16790,11 @@ snapshots:
       loose-envify: 1.4.0
 
   iron-webcrypto@1.2.1: {}
+
+  is-absolute@1.0.0:
+    dependencies:
+      is-relative: 1.0.0
+      is-windows: 1.0.2
 
   is-array-buffer@3.0.4:
     dependencies:
@@ -15405,6 +16866,10 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
+  is-lower-case@2.0.2:
+    dependencies:
+      tslib: 2.6.3
+
   is-module@1.0.0: {}
 
   is-negative-zero@2.0.3: {}
@@ -15429,6 +16894,10 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-regexp@1.0.0: {}
+
+  is-relative@1.0.0:
+    dependencies:
+      is-unc-path: 1.0.0
 
   is-shared-array-buffer@1.0.3:
     dependencies:
@@ -15456,7 +16925,15 @@ snapshots:
 
   is-typedarray@1.0.0: {}
 
+  is-unc-path@1.0.0:
+    dependencies:
+      unc-path-regex: 0.1.2
+
   is-unicode-supported@0.1.0: {}
+
+  is-upper-case@2.0.2:
+    dependencies:
+      tslib: 2.6.3
 
   is-weakref@1.0.2:
     dependencies:
@@ -15492,6 +16969,10 @@ snapshots:
       unfetch: 4.2.0
     transitivePeerDependencies:
       - encoding
+
+  isomorphic-ws@5.0.0(ws@8.17.1):
+    dependencies:
+      ws: 8.17.1
 
   isows@1.0.3(ws@8.13.0):
     dependencies:
@@ -15865,6 +17346,8 @@ snapshots:
 
   jiti@1.21.6: {}
 
+  jiti@2.3.3: {}
+
   joi@17.13.3:
     dependencies:
       "@hapi/hoek": 9.3.0
@@ -15872,6 +17355,8 @@ snapshots:
       "@sideway/address": 4.1.5
       "@sideway/formula": 3.0.1
       "@sideway/pinpoint": 2.0.0
+
+  jose@5.9.4: {}
 
   joycon@3.1.1: {}
 
@@ -15941,6 +17426,11 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-to-pretty-yaml@1.2.2:
+    dependencies:
+      remedial: 1.0.8
+      remove-trailing-spaces: 1.0.8
 
   json5@2.2.3: {}
 
@@ -16034,6 +17524,19 @@ snapshots:
     transitivePeerDependencies:
       - uWebSockets.js
 
+  listr2@4.0.5(enquirer@2.4.1):
+    dependencies:
+      cli-truncate: 2.1.0
+      colorette: 2.0.20
+      log-update: 4.0.0
+      p-map: 4.0.0
+      rfdc: 1.4.1
+      rxjs: 7.8.1
+      through: 2.3.8
+      wrap-ansi: 7.0.0
+    optionalDependencies:
+      enquirer: 2.4.1
+
   listr2@8.2.3:
     dependencies:
       cli-truncate: 4.0.0
@@ -16111,6 +17614,13 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  log-update@4.0.0:
+    dependencies:
+      ansi-escapes: 4.3.2
+      cli-cursor: 3.1.0
+      slice-ansi: 4.0.0
+      wrap-ansi: 6.2.0
+
   log-update@6.0.0:
     dependencies:
       ansi-escapes: 6.2.1
@@ -16132,6 +17642,14 @@ snapshots:
   loupe@2.3.7:
     dependencies:
       get-func-name: 2.0.2
+
+  lower-case-first@2.0.2:
+    dependencies:
+      tslib: 2.6.3
+
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.6.3
 
   lru-cache@10.4.3: {}
 
@@ -16171,6 +17689,8 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  map-cache@0.2.2: {}
+
   marky@1.2.5: {}
 
   match-sorter@6.3.4:
@@ -16187,6 +17707,10 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meros@1.3.0(@types/node@20.14.12):
+    optionalDependencies:
+      "@types/node": 20.14.12
 
   mersenne-twister@1.1.0: {}
 
@@ -16467,6 +17991,8 @@ snapshots:
 
   multiformats@9.9.0: {}
 
+  mute-stream@0.0.8: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -16482,6 +18008,11 @@ snapshots:
   negotiator@0.6.3: {}
 
   neo-async@2.6.2: {}
+
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.6.3
 
   nocache@3.0.4: {}
 
@@ -16516,6 +18047,10 @@ snapshots:
   node-releases@2.0.18: {}
 
   node-stream-zip@1.15.0: {}
+
+  normalize-path@2.1.1:
+    dependencies:
+      remove-trailing-separator: 1.1.0
 
   normalize-path@3.0.0: {}
 
@@ -16655,13 +18190,28 @@ snapshots:
 
   p-map@2.1.0: {}
 
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.0: {}
 
+  param-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.6.3
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-filepath@1.0.2:
+    dependencies:
+      is-absolute: 1.0.0
+      map-cache: 0.2.2
+      path-root: 0.1.1
 
   parse-json@4.0.0:
     dependencies:
@@ -16677,6 +18227,16 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  pascal-case@3.1.2:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.3
+
+  path-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.6.3
+
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -16688,6 +18248,12 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-root-regex@0.1.2: {}
+
+  path-root@0.1.1:
+    dependencies:
+      path-root-regex: 0.1.2
 
   path-scurry@1.11.1:
     dependencies:
@@ -16787,11 +18353,11 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.39
 
-  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.39)(yaml@2.4.5):
+  postcss-load-config@6.0.1(jiti@2.3.3)(postcss@8.4.39)(yaml@2.4.5):
     dependencies:
       lilconfig: 3.1.2
     optionalDependencies:
-      jiti: 1.21.6
+      jiti: 2.3.3
       postcss: 8.4.39
       yaml: 2.4.5
 
@@ -16869,6 +18435,10 @@ snapshots:
   process-warning@1.0.0: {}
 
   progress@2.0.3: {}
+
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
 
   promise@8.3.0:
     dependencies:
@@ -17258,7 +18828,21 @@ snapshots:
       "@types/react": 18.3.3
       react: 18.3.1
 
+  relay-runtime@12.0.0:
+    dependencies:
+      "@babel/runtime": 7.24.8
+      fbjs: 3.0.5
+      invariant: 2.2.4
+    transitivePeerDependencies:
+      - encoding
+
+  remedial@1.0.8: {}
+
   remove-accents@0.5.0: {}
+
+  remove-trailing-separator@1.1.0: {}
+
+  remove-trailing-spaces@1.0.8: {}
 
   require-directory@2.1.1: {}
 
@@ -17334,6 +18918,8 @@ snapshots:
       "@rollup/rollup-win32-x64-msvc": 4.19.0
       fsevents: 2.3.3
 
+  run-async@2.4.1: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -17371,6 +18957,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scuid@1.1.0: {}
+
   selfsigned@2.4.1:
     dependencies:
       "@types/node-forge": 1.3.11
@@ -17399,6 +18987,12 @@ snapshots:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  sentence-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.3
+      upper-case-first: 2.0.2
 
   serialize-error@2.1.0: {}
 
@@ -17432,6 +19026,8 @@ snapshots:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -17488,6 +19084,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  signedsource@1.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -17510,6 +19108,18 @@ snapshots:
       astral-regex: 1.0.0
       is-fullwidth-code-point: 2.0.0
 
+  slice-ansi@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.1
@@ -17521,6 +19131,11 @@ snapshots:
       is-fullwidth-code-point: 5.0.0
 
   smob@1.5.0: {}
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.6.3
 
   sonic-boom@2.8.0:
     dependencies:
@@ -17559,6 +19174,10 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sponge-case@1.0.1:
+    dependencies:
+      tslib: 2.6.3
+
   sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
@@ -17581,6 +19200,8 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
+  streamsearch@1.1.0: {}
+
   streamx@2.19.0:
     dependencies:
       fast-fifo: 1.3.2
@@ -17592,6 +19213,8 @@ snapshots:
   strict-uri-encode@2.0.0: {}
 
   string-argv@0.3.2: {}
+
+  string-env-interpolation@1.0.1: {}
 
   string-length@4.0.2:
     dependencies:
@@ -17728,6 +19351,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swap-case@2.0.2:
+    dependencies:
+      tslib: 2.6.3
 
   symbol-observable@4.0.0: {}
 
@@ -17905,6 +19532,8 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  through@2.3.8: {}
+
   tinybench@2.8.0: {}
 
   tinyglobby@0.2.5:
@@ -17915,6 +19544,10 @@ snapshots:
   tinypool@0.8.4: {}
 
   tinyspy@2.2.1: {}
+
+  title-case@3.0.3:
+    dependencies:
+      tslib: 2.6.3
 
   tmp@0.0.33:
     dependencies:
@@ -17971,11 +19604,13 @@ snapshots:
       "@jest/types": 29.6.3
       babel-jest: 29.7.0(@babel/core@7.25.2)
 
+  ts-log@2.2.7: {}
+
   tslib@1.14.1: {}
 
   tslib@2.6.3: {}
 
-  tsup@8.2.3(@swc/core@1.7.22)(jiti@1.21.6)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5):
+  tsup@8.2.3(@swc/core@1.7.22)(jiti@2.3.3)(postcss@8.4.39)(typescript@5.5.4)(yaml@2.4.5):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.0)
       cac: 6.7.14
@@ -17987,7 +19622,7 @@ snapshots:
       globby: 11.1.0
       joycon: 3.1.1
       picocolors: 1.0.1
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.39)(yaml@2.4.5)
+      postcss-load-config: 6.0.1(jiti@2.3.3)(postcss@8.4.39)(yaml@2.4.5)
       resolve-from: 5.0.0
       rollup: 4.19.0
       source-map: 0.8.0-beta.0
@@ -18101,6 +19736,8 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
+  unc-path-regex@0.1.2: {}
+
   unconfig@0.3.13:
     dependencies:
       "@antfu/utils": 0.7.10
@@ -18139,6 +19776,10 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unixify@1.0.0:
+    dependencies:
+      normalize-path: 2.1.1
 
   unpipe@1.0.0: {}
 
@@ -18186,11 +19827,21 @@ snapshots:
       escalade: 3.1.2
       picocolors: 1.0.1
 
+  upper-case-first@2.0.2:
+    dependencies:
+      tslib: 2.6.3
+
+  upper-case@2.0.2:
+    dependencies:
+      tslib: 2.6.3
+
   uqr@0.1.2: {}
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  urlpattern-polyfill@10.0.0: {}
 
   use-callback-ref@1.3.2(@types/react@18.3.3)(react@18.3.1):
     dependencies:
@@ -18234,6 +19885,8 @@ snapshots:
     optionalDependencies:
       "@types/react": 18.3.3
       react: 18.3.1
+
+  value-or-promise@1.0.12: {}
 
   vary@1.1.2: {}
 
@@ -18625,6 +20278,8 @@ snapshots:
   yallist@2.1.2: {}
 
   yallist@3.1.1: {}
+
+  yaml-ast-parser@0.0.43: {}
 
   yaml@2.4.5: {}
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on integrating GraphQL queries and types into the web application, enhancing type safety and data fetching capabilities. It also updates the project configuration for code generation.

### Detailed summary
- Added a new directory `src/_generated_/` for GraphQL types.
- Introduced `CodegenConfig` in `codegen.ts` for GraphQL code generation.
- Updated components to use `ExplorerTxByIdQuery` for type safety.
- Removed legacy `HistoryRecord` types and queries.
- Modified `package.json` scripts for GraphQL code generation.
- Updated `pnpm-lock.yaml` with new dependencies related to GraphQL code generation.

> The following files were skipped due to too many changes: `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->