### PR TITLE
Fix ipfs display check

### DIFF
--- a/apps/helixbox-app/src/components/footer.tsx
+++ b/apps/helixbox-app/src/components/footer.tsx
@@ -76,7 +76,7 @@ function Links() {
           ),
         )}
 
-      {window.location.hostname !== "app.helix.box" && (
+      {window.location.hostname === "app.helix.box" && (
         <Tooltip
           contentClassName="w-72"
           className="inline-flex items-center"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies a conditional rendering statement in the `footer.tsx` file to change the logic for displaying a `Tooltip` based on the `window.location.hostname`.

### Detailed summary
- Changed the conditional from `!== "app.helix.box"` to `=== "app.helix.box"` for rendering the `Tooltip`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->