### PR TITLE
Update careers link

### DIFF
--- a/apps/helixbox-home/src/components/homepage-footer.tsx
+++ b/apps/helixbox-home/src/components/homepage-footer.tsx
@@ -34,7 +34,7 @@ export default function HomepageFooter() {
           title="Resources"
           items={[
             { label: "Docs", link: "https://docs.helix.box/" },
-            { label: "Careers", link: "https://apply.workable.com/itering/" },
+            { label: "Careers", link: "https://itering-io.breezy.hr/" },
           ]}
           className="flex-shrink-[0.6] flex-grow-[0.6] basis-0"
         />

--- a/apps/helixbox-home/src/components/homepage-header.tsx
+++ b/apps/helixbox-home/src/components/homepage-header.tsx
@@ -15,7 +15,7 @@ const navigations: (
     ],
   },
   { label: "Docs", link: "https://docs.helix.box/" },
-  { label: "Careers", link: "https://apply.workable.com/itering/" },
+  { label: "Careers", link: "https://itering-io.breezy.hr/" },
 ];
 
 export default function HomepageHeader() {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the link for the "Careers" section in both the `HomepageHeader` and `HomepageFooter` components from an outdated URL to a new one.

### Detailed summary
- In `homepage-header.tsx`, changed the "Careers" link from `https://apply.workable.com/itering/` to `https://itering-io.breezy.hr/`.
- In `homepage-footer.tsx`, changed the "Careers" link from `https://apply.workable.com/itering/` to `https://itering-io.breezy.hr/`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->