### PR TITLE
Add prod mode for helix testnet

### DIFF
--- a/.github/workflows/app-deploy-prd.yml
+++ b/.github/workflows/app-deploy-prd.yml
@@ -42,6 +42,7 @@ jobs:
           vercel_group: itering
           preview_section: helix-app-testnet
           preview_output: true
+          prod_mode: true
           project_name: "helix-apps-test"
           script_install: pnpm install
           script_build: pnpm app build:testnet


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the GitHub Actions workflow configuration for deploying a production version of the `helix-apps-test` project.

### Detailed summary
- Added `prod_mode: true` to enable production mode in the workflow.
- Maintained existing settings for `preview_section`, `preview_output`, `project_name`, `script_install`, and `script_build`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->