### PR TITLE
Fix slack channel for packages release notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: steps.changesets.outputs.published == 'true'
         env:
-          slack_channel: helixbox-ui
+          SLACK_CHANNEL: helixbox-ui
           SLACK_COLOR: ${{ job.status }}
           SLACK_ICON: https://avatars.githubusercontent.com/u/51163350?s=48&v=4
           SLACK_MESSAGE: ${{ steps.changesets.outputs.publishedPackages }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the environment variable naming convention in the `.github/workflows/release.yml` file, changing the `slack_channel` variable to `SLACK_CHANNEL` to follow a consistent uppercase format.

### Detailed summary
- Changed `slack_channel` to `SLACK_CHANNEL` in the environment variables section of `.github/workflows/release.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->