### PR TITLE
Chains package sync helixconf

### DIFF
--- a/.changeset/spicy-suits-think.md
+++ b/.changeset/spicy-suits-think.md
@@ -1,0 +1,5 @@
+---
+"@helixbridge/chains": patch
+---
+
+Synchronize helixconf

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -35,7 +35,7 @@
     "preset": "@helixbridge/jest-presets/node"
   },
   "dependencies": {
-    "@helixbridge/helixconf": "1.1.18",
+    "@helixbridge/helixconf": "v1.2.0-beta",
     "viem": "^2.21.19"
   }
 }

--- a/packages/chains/src/chains/celo-testnet.ts
+++ b/packages/chains/src/chains/celo-testnet.ts
@@ -1,0 +1,9 @@
+import { Chain } from "../types";
+import { celoAlfajores } from "viem/chains";
+
+export const celoTestnet: Chain = {
+  ...celoAlfajores,
+  network: "celo-testnet",
+  name: "Celo Alfajores",
+  logo: "https://raw.githubusercontent.com/helix-bridge/helix-ui/main/packages/assets/images/chains/celo.png",
+};

--- a/packages/chains/src/chains/index.ts
+++ b/packages/chains/src/chains/index.ts
@@ -26,3 +26,4 @@ export * from "./zksync";
 export * from "./zksync-sepolia";
 export * from "./zircuit";
 export * from "./zircuit-sepolia";
+export * from "./celo-testnet";

--- a/packages/chains/src/types/index.ts
+++ b/packages/chains/src/types/index.ts
@@ -35,6 +35,7 @@ export enum ChainID {
   AVALANCHE = 43_114,
   ZIRCUIT_SEPOLIA = 48899,
   ZIRCUIT = 48900,
+  CELO_TESTNET = 44787,
 }
 /* eslint-enable no-unused-vars */
 
@@ -67,7 +68,8 @@ export type Network =
   | "avalanche"
   | "bsc"
   | "zircuit"
-  | "zircuit-sepolia";
+  | "zircuit-sepolia"
+  | "celo-testnet";
 
 export interface Chain extends ViemChain {
   id: ChainID;

--- a/packages/chains/src/utils/index.ts
+++ b/packages/chains/src/utils/index.ts
@@ -27,6 +27,7 @@ import {
   zircuitSepolia,
   zkSync,
   zksyncSepolia,
+  celoTestnet,
 } from "../chains";
 import { ChainID, type Network } from "../types";
 
@@ -59,6 +60,7 @@ export function getChains() {
     zkSync,
     zircuit,
     zircuitSepolia,
+    celoTestnet,
   ];
 }
 
@@ -145,6 +147,9 @@ export function getChainByIdOrNetwork(chainIdOrNetwork: ChainID | Network | null
     case ChainID.ZIRCUIT_SEPOLIA:
     case "zircuit-sepolia":
       return zircuitSepolia;
+    case ChainID.CELO_TESTNET:
+    case "celo-testnet":
+      return celoTestnet;
     default:
       return;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
         version: 1.0.7(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)
       "@reown/appkit-adapter-wagmi":
         specifier: ^1.0.7
-        version: 1.0.7(f3kwnolqgggnwa3wyrus5szn2e)
+        version: 1.0.7(l3bqwg3q27kpoc3uzgnypsmksq)
       "@sentry/react":
         specifier: ^8.30.0
         version: 8.30.0(react@18.3.1)
@@ -175,7 +175,7 @@ importers:
         version: 2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       wagmi:
         specifier: ^2.12.17
-        version: 2.12.17(@tanstack/query-core@5.59.0)(@tanstack/react-query@5.59.0(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@2.79.1)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+        version: 2.12.17(@tanstack/query-core@5.59.0)(@tanstack/react-query@5.59.0(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.19.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
     devDependencies:
       "@graphql-codegen/cli":
         specifier: 5.0.3
@@ -370,8 +370,8 @@ importers:
   packages/chains:
     dependencies:
       "@helixbridge/helixconf":
-        specifier: 1.1.18
-        version: 1.1.18
+        specifier: v1.2.0-beta
+        version: 1.2.0-beta
       viem:
         specifier: ^2.21.19
         version: 2.21.40(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -2123,10 +2123,6 @@ packages:
   "@helixbridge/contracts@0.1.0":
     resolution:
       { integrity: sha512-nStR0wpdP0yEbZkEe4NOIxqUczoR5hN6JQ/N1Sj+R1ZrgkkXLcyahQiw/CJlPRb4mkAk8nBMa6G8IbLln2QLWw== }
-
-  "@helixbridge/helixconf@1.1.18":
-    resolution:
-      { integrity: sha512-3o4urkcBMMs5JGuDrgcnRt909LWHhlVkMpVodQU5m4tm94trETnmf1dvHhSZGA/TBGffeC/82UMdqmx/w2NnEg== }
 
   "@helixbridge/helixconf@1.2.0-beta":
     resolution:
@@ -11308,8 +11304,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  "@helixbridge/helixconf@1.1.18": {}
-
   "@helixbridge/helixconf@1.2.0-beta": {}
 
   "@humanwhocodes/config-array@0.11.14":
@@ -11663,7 +11657,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-native: 0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10)
 
-  "@metamask/sdk@0.28.4(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@2.79.1)(utf-8-validate@5.0.10)":
+  "@metamask/sdk@0.28.4(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.19.0)(utf-8-validate@5.0.10)":
     dependencies:
       "@metamask/onboarding": 1.0.1
       "@metamask/providers": 16.1.0
@@ -11684,7 +11678,7 @@ snapshots:
       qrcode-terminal-nooctal: 0.12.1
       react-native-webview: 11.26.1(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)
       readable-stream: 3.6.2
-      rollup-plugin-visualizer: 5.12.0(rollup@2.79.1)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.19.0)
       socket.io-client: 4.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       util: 0.12.5
       uuid: 8.3.2
@@ -12182,7 +12176,7 @@ snapshots:
 
   "@remix-run/router@1.20.0": {}
 
-  "@reown/appkit-adapter-wagmi@1.0.7(f3kwnolqgggnwa3wyrus5szn2e)":
+  "@reown/appkit-adapter-wagmi@1.0.7(l3bqwg3q27kpoc3uzgnypsmksq)":
     dependencies:
       "@coinbase/wallet-sdk": 4.0.4
       "@reown/appkit": 1.0.7(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)
@@ -12194,13 +12188,13 @@ snapshots:
       "@reown/appkit-ui": 1.0.7
       "@reown/appkit-utils": 1.0.7(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)(valtio@1.11.2(@types/react@18.3.3)(react@18.3.1))
       "@reown/appkit-wallet": 1.0.7
-      "@wagmi/connectors": 5.1.15(@types/react@18.3.3)(@wagmi/core@2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@2.79.1)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+      "@wagmi/connectors": 5.1.15(@types/react@18.3.3)(@wagmi/core@2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.19.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
       "@wagmi/core": 2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
       "@walletconnect/universal-provider": 2.17.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       "@walletconnect/utils": 2.17.0
       valtio: 1.11.2(@types/react@18.3.3)(react@18.3.1)
       viem: 2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
-      wagmi: 2.12.17(@tanstack/query-core@5.59.0)(@tanstack/react-query@5.59.0(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@2.79.1)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+      wagmi: 2.12.17(@tanstack/query-core@5.59.0)(@tanstack/react-query@5.59.0(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.19.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
     transitivePeerDependencies:
       - "@azure/app-configuration"
       - "@azure/cosmos"
@@ -13080,10 +13074,10 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  "@wagmi/connectors@5.1.15(@types/react@18.3.3)(@wagmi/core@2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@2.79.1)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)":
+  "@wagmi/connectors@5.1.15(@types/react@18.3.3)(@wagmi/core@2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.19.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)":
     dependencies:
       "@coinbase/wallet-sdk": 4.0.4
-      "@metamask/sdk": 0.28.4(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@2.79.1)(utf-8-validate@5.0.10)
+      "@metamask/sdk": 0.28.4(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.19.0)(utf-8-validate@5.0.10)
       "@safe-global/safe-apps-provider": 0.18.3(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       "@safe-global/safe-apps-sdk": 9.1.0(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       "@wagmi/core": 2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
@@ -17325,14 +17319,14 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-visualizer@5.12.0(rollup@2.79.1):
+  rollup-plugin-visualizer@5.12.0(rollup@4.19.0):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 2.79.1
+      rollup: 4.19.0
 
   rollup@2.79.1:
     optionalDependencies:
@@ -18401,10 +18395,10 @@ snapshots:
 
   vlq@1.0.1: {}
 
-  wagmi@2.12.17(@tanstack/query-core@5.59.0)(@tanstack/react-query@5.59.0(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@2.79.1)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4):
+  wagmi@2.12.17(@tanstack/query-core@5.59.0)(@tanstack/react-query@5.59.0(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.19.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4):
     dependencies:
       "@tanstack/react-query": 5.59.0(react@18.3.1)
-      "@wagmi/connectors": 5.1.15(@types/react@18.3.3)(@wagmi/core@2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@2.79.1)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+      "@wagmi/connectors": 5.1.15(@types/react@18.3.3)(@wagmi/core@2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.5.4)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.19.0)(typescript@5.5.4)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
       "@wagmi/core": 2.13.8(@tanstack/query-core@5.59.0)(@types/react@18.3.3)(react@18.3.1)(typescript@5.5.4)(viem@2.21.19(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4))
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding support for the `celo-testnet` to the project, updating dependencies, and synchronizing configurations. It introduces new types and exports related to the `Celo` network.

### Detailed summary
- Added `CELO_TESTNET` to the `Network` type in `packages/chains/src/types/index.ts`.
- Exported `celoTestnet` from `packages/chains/src/chains/celo-testnet.ts`.
- Updated `getChains` function to include `celoTestnet`.
- Modified `getChainByIdOrNetwork` to handle `celo-testnet`.
- Updated dependency version for `@helixbridge/helixconf` in `packages/chains/package.json` and `pnpm-lock.yaml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->