### PR TITLE
Release sdk-bridge

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["helix", "helixbox-home", "helixbox-app"]
+  "ignore": ["helix", "helixbox-home", "helixbox-app", "sdks-playground"]
 }

--- a/.changeset/sixty-moons-retire.md
+++ b/.changeset/sixty-moons-retire.md
@@ -1,0 +1,5 @@
+---
+"@helixbridge/sdk-bridge": patch
+---
+
+Release sdk-bridge

--- a/apps/sdks-playground/CHANGELOG.md
+++ b/apps/sdks-playground/CHANGELOG.md
@@ -1,9 +1,0 @@
-# sdks-playground
-
-## 0.0.1
-
-### Patch Changes
-
-- Updated dependencies [785f040]
-  - @helixbridge/sdk-indexer@0.1.0
-  - @helixbridge/sdk-bridge@0.0.1

--- a/apps/sdks-playground/package.json
+++ b/apps/sdks-playground/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdks-playground",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -36,10 +36,10 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@helixbridge/chains": "workspace:*",
+    "@helixbridge/chains": "0.5.1",
     "@helixbridge/helixconf": "v1.2.0-beta",
-    "@helixbridge/sdk-core": "workspace:*",
-    "@helixbridge/sdk-indexer": "workspace:*",
+    "@helixbridge/sdk-core": "0.1.0",
+    "@helixbridge/sdk-indexer": "0.1.0",
     "viem": "^2.21.19"
   }
 }

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@helixbridge/sdk-bridge",
   "version": "0.0.1",
-  "private": true,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,17 +486,17 @@ importers:
   packages/sdk-bridge:
     dependencies:
       "@helixbridge/chains":
-        specifier: workspace:*
-        version: link:../chains
+        specifier: 0.5.1
+        version: 0.5.1(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       "@helixbridge/helixconf":
         specifier: v1.2.0-beta
         version: 1.2.0-beta
       "@helixbridge/sdk-core":
-        specifier: workspace:*
-        version: link:../sdk-core
+        specifier: 0.1.0
+        version: 0.1.0(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       "@helixbridge/sdk-indexer":
-        specifier: workspace:*
-        version: link:../sdk-indexer
+        specifier: 0.1.0
+        version: 0.1.0(@types/react@18.3.12)(bufferutil@4.0.8)(graphql-ws@5.16.0(graphql@16.9.0))(react-dom@18.3.1(react@18.3.1))(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
       viem:
         specifier: ^2.21.19
         version: 2.21.44(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -2458,6 +2458,14 @@ packages:
   "@helixbridge/helixconf@1.2.0-beta":
     resolution:
       { integrity: sha512-YuFOhX33quFUwOvduSzo01ul7SWus2OicDTulJLbPdg000Qs37s0WJ80n1fK8FSDgvBMToC8oaxnimwTl6fT9Q== }
+
+  "@helixbridge/sdk-core@0.1.0":
+    resolution:
+      { integrity: sha512-vn0J9sLoGBwFZeVTvU/vqjDYYVnJVyfqWvY/jW8J88uNbV0t0u3YTMSTYt6PXJAKDimslQBWhp97rCUrqHQ0uw== }
+
+  "@helixbridge/sdk-indexer@0.1.0":
+    resolution:
+      { integrity: sha512-NeBxUfogCGYJbhI1NqbQaZXqWa3c8Y0A8IPp/wcaBAPjrt8QNKeZNk2U4q0C90gXg3qUrU7HnbEtbEcMx6RsTA== }
 
   "@humanfs/core@0.19.1":
     resolution:
@@ -13288,6 +13296,33 @@ snapshots:
       - zod
 
   "@helixbridge/helixconf@1.2.0-beta": {}
+
+  "@helixbridge/sdk-core@0.1.0(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)":
+    dependencies:
+      viem: 2.21.44(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  "@helixbridge/sdk-indexer@0.1.0(@types/react@18.3.12)(bufferutil@4.0.8)(graphql-ws@5.16.0(graphql@16.9.0))(react-dom@18.3.1(react@18.3.1))(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)":
+    dependencies:
+      "@apollo/client": 3.11.1(@types/react@18.3.12)(graphql-ws@5.16.0(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@helixbridge/chains": 0.5.1(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+      "@helixbridge/helixconf": 1.2.0-beta
+      graphql: 16.9.0
+      react: 18.3.1
+      viem: 2.21.44(bufferutil@4.0.8)(typescript@5.5.4)(utf-8-validate@5.0.10)(zod@3.22.4)
+    transitivePeerDependencies:
+      - "@types/react"
+      - bufferutil
+      - graphql-ws
+      - react-dom
+      - subscriptions-transport-ws
+      - typescript
+      - utf-8-validate
+      - zod
 
   "@humanfs/core@0.19.1": {}
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the versioning and dependencies of the `sdk-bridge` package and related configurations in the `sdks-playground` project.

### Detailed summary
- Deleted `CHANGELOG.md.changeset/sixty-moons-retire.md`.
- Updated `version` of `sdks-playground` from `0.0.1` to `0.0.0`.
- Added `sdks-playground` to the `ignore` list in `.changeset/config.json`.
- Updated dependencies in `@helixbridge/sdk-bridge` from workspace references to specific versions.
- Updated `pnpm-lock.yaml` to reflect new dependency versions and resolutions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->