### PR TITLE
Fix appkit networks

### DIFF
--- a/apps/helixbox-app/src/providers/walletconnect-provider.tsx
+++ b/apps/helixbox-app/src/providers/walletconnect-provider.tsx
@@ -23,15 +23,7 @@ const metadata = {
 // 3. Set the networks
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const networks = getChainConfigs().map(({ tokens, ...chain }) => ({
-  id: `eip155:${chain.id}`,
-  caipNetworkId: `eip155:${chain.id}`,
-  chainId: chain.id,
-  chainNamespace: "eip155",
-  name: chain.name,
-  nativeCurrency: chain.nativeCurrency,
-  explorerUrl: chain.blockExplorers?.default?.url || "",
-  rpcUrls: chain.rpcUrls,
-  imageUrl: chain.logo,
+  ...chain,
 }));
 
 // 4. Create Wagmi Adapter


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `networks` constant in the `walletconnect-provider.tsx` file to simplify its structure by spreading the properties of `chain` instead of manually specifying them.

### Detailed summary
- Replaced the manual mapping of `chain` properties in the `networks` constant with the spread operator `...chain`, simplifying the code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->