### PR TITLE
Fix mainnet rpc

### DIFF
--- a/apps/helixbox-app/src/config/chains/ethereum.ts
+++ b/apps/helixbox-app/src/config/chains/ethereum.ts
@@ -54,6 +54,11 @@ export const ethereumChain: ChainConfig = {
   ...mainnet,
   network: "ethereum",
   name: "Ethereum",
+  rpcUrls: {
+    default: {
+      http: ["https://1rpc.io/eth"],
+    },
+  },
 
   /**
    * Custom

--- a/apps/helixbox-app/src/config/chains/ethereum.ts
+++ b/apps/helixbox-app/src/config/chains/ethereum.ts
@@ -56,7 +56,7 @@ export const ethereumChain: ChainConfig = {
   name: "Ethereum",
   rpcUrls: {
     default: {
-      http: ["https://1rpc.io/eth"],
+      http: ["https://eth.merkle.io"],
     },
   },
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds an `rpcUrls` configuration for the `Ethereum` network in the `ethereum.ts` file, specifying a default HTTP endpoint.

### Detailed summary
- Added `rpcUrls` object for the `Ethereum` network.
- Defined a `default` property within `rpcUrls`.
- Set the `http` array with the URL `"https://eth.merkle.io"` as the endpoint.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->