### PR TITLE
Remove Testnet from Production Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Production
 
 - mainnet: https://app.helixbox.ai (ipfs version: https://helixbridge.eth.limo)
-- testnet: https://testnet.app.helixbox.ai
+- ~~testnet: https://testnet-app.helixbox.ai~~
 
 ### Staging
 

--- a/apps/helixbox-app/README.md
+++ b/apps/helixbox-app/README.md
@@ -3,7 +3,7 @@
 ### Production
 
 - mainnet: https://app.helixbox.ai (ipfs version: https://helixbridge.eth.limo)
-- testnet: https://testnet.app.helixbox.ai
+- ~~testnet: https://testnet-app.helixbox.ai~~
 
 ### Staging
 

--- a/apps/helixbox-app/scripts/generate-sitemap.js
+++ b/apps/helixbox-app/scripts/generate-sitemap.js
@@ -6,7 +6,6 @@ const pagesMeta = [
   { url: "https://app.helixbox.ai", priority: 1.0 },
   { url: "https://app.helixbox.ai/#/relayer", priority: 0.8 },
   { url: "https://app.helixbox.ai/#/explorer", priority: 0.8 },
-  { url: "https://testnet.app.helixbox.ai", priority: 0.8 },
 ];
 
 const urls = pagesMeta

--- a/apps/helixbox-app/src/components/footer.tsx
+++ b/apps/helixbox-app/src/components/footer.tsx
@@ -32,11 +32,7 @@ function Links() {
   const [network, setNetwork] = useState<TData>({ label: "Saa", path: "ss", pc: true, external: true });
 
   useEffect(() => {
-    if (window.location.hostname === "app.helixbox.ai") {
-      setNetwork((prev) => ({ ...prev, label: "Testnet", path: "https://testnet-app.helixbox.ai" }));
-    } else if (window.location.hostname === "testnet-app.helixbox.ai") {
-      setNetwork((prev) => ({ ...prev, label: "Mainnet", path: "https://app.helixbox.ai" }));
-    } else if (window.location.hostname === "helixbox-stg-mainnet.vercel.app") {
+    if (window.location.hostname === "helixbox-stg-mainnet.vercel.app") {
       setNetwork((prev) => ({ ...prev, label: "Testnet", path: "https://helixbox-stg-testnet.vercel.app" }));
     } else if (window.location.hostname === "helixbox-stg-testnet.vercel.app") {
       setNetwork((prev) => ({ ...prev, label: "Mainnet", path: "https://helixbox-stg-mainnet.vercel.app" }));


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating URLs related to the `testnet` environment in the documentation and codebase of the `helixbox` application, ensuring consistency across various files.

### Detailed summary
- Removed `testnet` URL from `README.md` and `apps/helixbox-app/README.md`.
- Updated `testnet` URL in `apps/helixbox-app/scripts/generate-sitemap.js`.
- Modified `useEffect` logic in `apps/helixbox-app/src/components/footer.tsx` for network path handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->