### PR TITLE
Add redundancy to the nativeFee obtained from the result

### DIFF
--- a/apps/helixbox-app/src/bridges/lnbridge-base.ts
+++ b/apps/helixbox-app/src/bridges/lnbridge-base.ts
@@ -56,9 +56,9 @@ export class LnBridgeBase extends BaseBridge {
       address: sendService,
       abi: (await import(`../abi/lnaccess-controller`)).default,
       functionName: "fee",
-      args: [BigInt(remoteChain.id), bytesToHex(Uint8Array.from([123]), { size: Math.ceil(messageSizeInByte * 1.01) })], // To leave some margin, we added a 1% redundancy.
+      args: [BigInt(remoteChain.id), bytesToHex(Uint8Array.from([123]), { size: messageSizeInByte })],
     });
-    return nativeFee;
+    return (nativeFee * 110n) / 100n; // To leave some margin, we added a 10% redundancy.
   }
 
   protected async _getMsglineFeeAndParams(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adjusting the arguments for a function call in the `lnbridge-base.ts` file and modifying the return value to include a 10% redundancy instead of a 1% redundancy.

### Detailed summary
- Changed the `args` array to remove the 1% redundancy in the `size` parameter.
- Updated the return statement to apply a 10% redundancy to `nativeFee`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->