### PR TITLE
update: using new host for fee

### DIFF
--- a/apps/helixbox-app/src/utils/misc.ts
+++ b/apps/helixbox-app/src/utils/misc.ts
@@ -56,7 +56,7 @@ export async function fetchMsglineFeeAndParams(
   payload: Hex,
 ) {
   // const endpoint = 'https://msgport-api.darwinia.network';  // v1
-  const endpoint = "https://api.msgport.xyz"; // v2
+  const endpoint = "https://msgport-api.ringdao.com"; // v2
 
   const feeData = await fetch(
     `${endpoint}/ormp/fee?from_chain_id=${fromChainId}&to_chain_id=${toChainId}&payload=${payload}&from_address=${fromMessager}&to_address=${toMessager}&refund_address=${sender}`,

--- a/packages/sdk-bridge/src/utils/misc.ts
+++ b/packages/sdk-bridge/src/utils/misc.ts
@@ -8,7 +8,7 @@ export async function fetchMsgportFeeAndParams(
   refundAddress: Address,
   payload: Hash,
 ) {
-  const endpoint = "https://api.msgport.xyz";
+  const endpoint = "https://msgport-api.ringdao.com";
 
   const feeRes = await fetch(
     `${endpoint}/ormp/fee?from_chain_id=${fromChainId}&to_chain_id=${toChainId}&payload=${payload}&from_address=${fromAddress}&to_address=${toAddress}&refund_address=${refundAddress}`,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the API endpoint used in two files to point to a new URL for the `msgport` service.

### Detailed summary
- In `packages/sdk-bridge/src/utils/misc.ts`, the `endpoint` was changed from `"https://api.msgport.xyz"` to `"https://msgport-api.ringdao.com"`.
- In `apps/helixbox-app/src/utils/misc.ts`, the `endpoint` was also updated from `"https://api.msgport.xyz"` to `"https://msgport-api.ringdao.com"` with a comment indicating it as v2.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->